### PR TITLE
Collection label_method and value_method

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -105,7 +105,7 @@ Collection inputs accepts two other options beside collections:
 
 * value_method => the value method to be applied to the collection to retrieve the value
 
-Those methods are useful to manipulate the given collection. All other options given are sent straight to the underlying helper. For example, you can give prompt as:
+Those methods are useful to manipulate the given collection. Both of these options also except lambda/procs incase you want to calculate the value or label in a special way eg. custom translation. All other options given are sent straight to the underlying helper. For example, you can give prompt as:
 
   f.input :age, :collection => 18..60, :prompt => "Select your age"
 

--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -31,8 +31,8 @@ module SimpleForm
       #
       def collection_radio(attribute, collection, value_method, text_method, options={}, html_options={})
         collection.map do |item|
-          value = item.send value_method
-          text  = item.send text_method
+          value = (value_method.respond_to?(:call) ? value_method.call(item) : item.send(value_method))
+          text  = (text_method.respond_to?(:call)  ? text_method.call(item)  : item.send(text_method))
 
           default_html_options = default_html_options_for_collection(item, value, options, html_options)
 
@@ -70,8 +70,8 @@ module SimpleForm
       #
       def collection_check_boxes(attribute, collection, value_method, text_method, options={}, html_options={})
         collection.map do |item|
-          value = item.send value_method
-          text  = item.send text_method
+          value = (value_method.respond_to?(:call) ? value_method.call(item) : item.send(value_method))
+          text  = (text_method.respond_to?(:call)  ? text_method.call(item)  : item.send(text_method))
 
           default_html_options = default_html_options_for_collection(item, value, options, html_options)
           default_html_options[:multiple] = true

--- a/test/inputs_test.rb
+++ b/test/inputs_test.rb
@@ -327,6 +327,17 @@ class InputTest < ActionView::TestCase
     assert_select 'label.collection_radio', 'CARLOS'
   end
 
+  test 'input should allow overriding label and value method using a lambda for collections' do
+    with_input_for @user, :name, :radio,
+                          :collection => ['Jose' , 'Carlos'],
+                          :label_method => lambda { |i| i.upcase },
+                          :value_method => lambda { |i| i.downcase }
+    assert_select 'input[type=radio][value=jose]'
+    assert_select 'input[type=radio][value=carlos]'
+    assert_select 'label.collection_radio', 'JOSE'
+    assert_select 'label.collection_radio', 'CARLOS'
+  end
+
   test 'input should allow symbols for collections' do
     with_input_for @user, :name, :select, :collection => [:jose, :carlos]
     assert_select 'select.select#user_name'


### PR DESCRIPTION
(moved http://github.com/plataformatec/simple_form/issues#issue/42 to a pull request issue)

Hi Guys,

We use Simple Form in our projects for all our forms. We had a use case where we have an array of values available for selection but wanted the label to be translated, which label_method would not allow.

I created a fork (http://github.com/joshk/simple_form) which allows label_method and value_method to accept a lambda which can then do custom processing/transformation of the collection value.

I think this would be a good addition to Simple Form, but please let me know what you think.

Thanks a bundle,

Josh
