### PR TITLE
input takes :components option to control components rendering

### DIFF
--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -51,7 +51,7 @@ module SimpleForm
     protected
 
       def components_list
-        SimpleForm.components
+        options[:components] || SimpleForm.components
       end
 
       def attribute_required?

--- a/lib/simple_form/version.rb
+++ b/lib/simple_form/version.rb
@@ -1,3 +1,3 @@
 module SimpleForm
-  VERSION = "1.2.2".freeze
+  VERSION = "1.2.2"#.freeze
 end

--- a/test/inputs_test.rb
+++ b/test/inputs_test.rb
@@ -27,6 +27,32 @@ class InputTest < ActionView::TestCase
     assert_select 'select.datetime'
   end
 
+  test 'input should render components according to an optional :components option' do
+    with_input_for @user, :name, :string, :components => [:input, :label]
+    assert_select 'input + label'
+
+    with_input_for @user, :age, :integer, :components => [:input, :label]
+    assert_select 'input + label'
+
+    with_input_for @user, :active, :boolean, :components => [:label, :input]
+    assert_select 'label + input'
+
+    with_input_for @user, :description, :text, :components => [:input, :label]
+    assert_select 'textarea + label'
+
+    with_input_for @user, :password, :password, :components => [:input, :label]
+    assert_select 'input + label'
+
+    with_input_for @user, :name, :file, :components => [:input, :label]
+    assert_select 'input + label'
+
+    with_input_for @user, :country, :country, :components => [:input, :label]
+    assert_select 'select + label'
+
+    with_input_for @user, :time_zone, :time_zone, :components => [:input, :label]
+    assert_select 'select + label'
+  end
+
   # StringInput
   test 'input should map text field to string attribute' do
     with_input_for @user, :name, :string


### PR DESCRIPTION
Hi guys,

I've monkey patched to allow input to optionally render components based on a hash key :components.

Cheers,
Khoa.
