### PR TITLE
Add input_html example to show setting a default value

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -59,6 +59,15 @@ You can also disable labels, hints or error or configure the html of any of them
     <%= f.button :submit %>
   <% end %>
 
+You can set a default value on an input using the input_html option:
+
+  <%= simple_form_for @user do |f| %>
+    <%= f.input :username %>
+    <%= f.input :password %>
+    <%= f.input :remember_me, :as => :hidden, :input_html => {:value => '1'} %>
+    <%= f.button :submit %>
+  <% end %>
+
 By default all inputs are required, which means an * is prepended to the label, but you can disable it in any input you want:
 
   <%= simple_form_for @user do |f| %>


### PR DESCRIPTION
Put a quick example in the readme to show how to set a default value for an input field.
