### PR TITLE
Rails uses en.helpers.label.model.attribute for i18n

### DIFF
--- a/lib/simple_form/components/labels.rb
+++ b/lib/simple_form/components/labels.rb
@@ -54,7 +54,7 @@ module SimpleForm
 
       # First check human attribute name and then labels.
       def label_translation #:nodoc:
-        translate(:labels) || if object.class.respond_to?(:human_attribute_name)
+        translate(:labels) || translate(:label, '', :helpers) || if object.class.respond_to?(:human_attribute_name)
           object.class.human_attribute_name(reflection_or_attribute_name.to_s)
         else
           attribute_name.to_s.humanize

--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -128,14 +128,14 @@ module SimpleForm
       #            email: 'E-mail.'
       #
       #  Take a look at our locale example file.
-      def translate(namespace, default='')
+      def translate(namespace, default='', primary_scope = 'simple_form')
         return nil unless SimpleForm.translate
         lookups = []
         lookups << :"#{object_name}.#{lookup_action}.#{reflection_or_attribute_name}"
         lookups << :"#{object_name}.#{reflection_or_attribute_name}"
         lookups << :"#{reflection_or_attribute_name}"
         lookups << default
-        I18n.t(lookups.shift, :scope => :"simple_form.#{namespace}", :default => lookups).presence
+        I18n.t(lookups.shift, :scope => :"#{primary_scope}.#{namespace}", :default => lookups).presence
       end
 
       # The action to be used in lookup.

--- a/test/components/label_test.rb
+++ b/test/components/label_test.rb
@@ -194,6 +194,13 @@ class LabelTest < ActionView::TestCase
     end
   end
 
+  test 'label should use i18n from Rails scope properly' do
+    store_translations(:en, :helpers => { :label => { :age => 'Umar' }} ) do
+      with_label_for @user, :age, :integer
+      assert_select 'label[for=user_age]', /Umar/
+    end
+  end
+
   test 'label should add required by default when object is not present' do
     with_label_for :project, :name, :string
     assert_select 'label.required[for=project_name]'


### PR DESCRIPTION
Rails looks up i18n for labels in scope en.helpers.label.model.attribute before falling back on the humanized attribute name.

Simple form however does not lookup that i18n scope, looking first for en.simple_form.labels.model.attribute before defaulting to the humanized attribute name.

If a user already has i18n files, they should be picked up just as Rails would when switching to simple_form. 
