### PR TITLE
Update associations for other ORM/DB types?

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -129,7 +129,7 @@ module SimpleForm
       raise "Association #{association.inspect} not found" unless @reflection
 
       case @reflection.macro
-        when :belongs_to
+        when :belongs_to, :referenced_in
           attribute = @reflection.options[:foreign_key] || :"#{@reflection.name}_id"
         when :has_one
           raise ":has_one association are not supported by f.association"


### PR DESCRIPTION
I'm not sure if this is something that might be worth doing, but I ran into this issue when converting an application from mysql to mongodb.

Right now the association is looking for specific macros (as provided by ActiveRecord) to determine the correct field to use. This change allows the referenced_in macro from mongoid to work. Clearly there would be a lot more that could be added, but I'm not sure if this is the direction you want to go.
