### PR TITLE
Render collection with disabled items

### DIFF
--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -137,6 +137,12 @@ module SimpleForm
         rendered_collection = collection.map do |item|
           value = value_for_collection(item, value_method)
           text  = value_for_collection(item, text_method)
+          
+          if item.respond_to?(:disabled)
+            disabled = value_for_collection(item, :disabled)
+            html_options.merge!(:disabled => 'disabled') if disabled
+          end
+          
           default_html_options = default_html_options_for_collection(item, value, options, html_options)
 
           rendered_item = yield value, text, default_html_options


### PR DESCRIPTION
We like to render collections from the database where we have a column set for disabled. The change allows the html_options to pick this up for each item when rendering a collection.

Cheers

Kev
