### PR TITLE
Add ability to wrap blocks and buttons specifically.

### DIFF
--- a/lib/simple_form/components/errors.rb
+++ b/lib/simple_form/components/errors.rb
@@ -30,7 +30,7 @@ module SimpleForm
       end
 
       def errors_on_attribute
-        object.errors[attribute_name]
+        attribute_name ? object.errors[attribute_name] : []
       end
 
       def errors_on_association

--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -242,6 +242,31 @@ module SimpleForm
       SimpleForm::ErrorNotification.new(self, options).render
     end
 
+    # Creates a wrapper with the given CSS class around the block. This is useful
+    # when you want to group items together, such as buttons.
+    #
+    # == Examples
+    #
+    #    f.wrapper :buttons do
+    #      link_to 'Cancel'
+    #      f.button :submit
+    #    end
+    #
+    def wrapper(wrapper_class, &block)
+      options = {
+        :components    => [ :label_input ],
+        :label         => false,
+        :required      => false,
+        :wrapper_class => wrapper_class.to_s
+      }
+      SimpleForm::Inputs::BlockInput.new(self, nil, nil, nil, options, &block).render
+    end
+
+    # Helper method for wrapping buttons.
+    def buttons(&block)
+      wrapper :buttons, &block
+    end
+
   private
 
     # Attempt to guess the better input type given the defined options. By

--- a/test/form_builder_test.rb
+++ b/test/form_builder_test.rb
@@ -39,6 +39,18 @@ class FormBuilderTest < ActionView::TestCase
     end
   end
 
+  def with_wrapper_for(object, *args, &block)
+    with_concat_form_for(object) do |f|
+      f.wrapper(*args, &block)
+    end
+  end
+
+  def with_buttons_for(object, *args, &block)
+    with_concat_form_for(object) do |f|
+      f.buttons(*args, &block)
+    end
+  end
+
   # All
   test 'nested simple fields should yields an instance of FormBuilder' do
     simple_form_for :user do |f|
@@ -258,6 +270,20 @@ class FormBuilderTest < ActionView::TestCase
       with_form_for @user, :name, :placeholder => false
       assert_no_select 'input[placeholder]'
     end
+  end
+
+  test 'builder should be able to generate a wrapper' do
+    with_wrapper_for @user, :buttons do
+      submit_tag
+    end
+    assert_select 'form div.buttons input[type=submit]'
+  end
+
+  test 'builder should be able to generate a button wrapper' do
+    with_buttons_for @user do
+      submit_tag
+    end
+    assert_select 'form div.buttons input[type=submit]'
   end
 
   # REQUIRED AND PRESENCE VALIDATION


### PR DESCRIPTION
The error i was getting (see my forum posts) where because attribute_name was nil. That's what the change in errors.rb is for. The rest is just for the feature.
