### PR TITLE
<input type="date" />

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -6,10 +6,9 @@ module SimpleForm
     include SimpleForm::Inputs
 
     map_type :password, :text, :file,              :to => SimpleForm::Inputs::MappingInput
-    map_type :string, :email, :search, :tel, :url, :to => SimpleForm::Inputs::StringInput
+    map_type :string, :email, :search, :tel, :url, :date, :datetime, :time, :to => SimpleForm::Inputs::StringInput
     map_type :integer, :decimal, :float,           :to => SimpleForm::Inputs::NumericInput
     map_type :select, :radio, :check_boxes,        :to => SimpleForm::Inputs::CollectionInput
-    map_type :date, :time, :datetime,              :to => SimpleForm::Inputs::DateTimeInput
     map_type :country, :time_zone,                 :to => SimpleForm::Inputs::PriorityInput
     map_type :boolean,                             :to => SimpleForm::Inputs::BooleanInput
 

--- a/lib/simple_form/inputs.rb
+++ b/lib/simple_form/inputs.rb
@@ -4,7 +4,6 @@ module SimpleForm
     autoload :BlockInput,      'simple_form/inputs/block_input'
     autoload :BooleanInput,    'simple_form/inputs/boolean_input'
     autoload :CollectionInput, 'simple_form/inputs/collection_input'
-    autoload :DateTimeInput,   'simple_form/inputs/date_time_input'
     autoload :HiddenInput,     'simple_form/inputs/hidden_input'
     autoload :MappingInput,    'simple_form/inputs/mapping_input'
     autoload :NumericInput,    'simple_form/inputs/numeric_input'


### PR DESCRIPTION
Instead of input type="select", with the traditional 1i, 2i, and 3i as it is in standard rails, i changed date, datetime and time for their own real html elements.
It's already the case for integer, phone numbers and email, so I did it for date, datetime and time.

One other point for doing that is that every time someone want to integrate some calendar widget (like the jquery one), they must change their :date to :string in order to have only one element. So I think it's a pretty useful change.

Some tests are broken, but if you are interested in integrating these changes, I would be happy to contribute and to rewrite some of the tests (because a lot will be deprecated since it's a big change)
What do you think ?
