### PR TITLE
Bugfix for issue 195

### DIFF
--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -99,10 +99,10 @@ module SimpleForm
       #   end
       def simple_fields_for(*args, &block)
         options = args.extract_options!
-        if self.class < SimpleForm::FormBuilder
-          options[:builder] = self.class
+        if self.class < ActionView::Helpers::FormBuilder
+          options[:builder] ||= self.class
         else
-          options[:builder] = SimpleForm::FormBuilder
+          options[:builder] ||= SimpleForm::FormBuilder
         end
         fields_for(*(args << options), &block)
       end

--- a/test/action_view_extensions/form_helper_test.rb
+++ b/test/action_view_extensions/form_helper_test.rb
@@ -34,4 +34,24 @@ class FormHelperTest < ActionView::TestCase
       assert f.instance_of?(SimpleForm::FormBuilder)
     end)
   end
+  
+  test 'fields for yields an instance of CustomBuilder if main builder is a CustomBuilder' do
+    concat(simple_form_for(:user, :url => '/account', :html => { :id => 'my_form' }, :builder => CustomBuilder) do |form|
+      assert form.instance_of?(CustomBuilder)
+      
+      form.simple_fields_for(:company) do |company|
+        assert company.instance_of?(CustomBuilder)
+      end
+    end)
+  end
+  
+  test 'fields for yields an instance of FormBuilder if it was set in options' do
+    concat(simple_form_for(:user, :url => '/account', :html => { :id => 'my_form' }, :builder => CustomBuilder) do |form|
+      assert form.instance_of?(CustomBuilder)
+      
+      form.simple_fields_for(:company, :builder => SimpleForm::FormBuilder) do |company|
+        assert company.instance_of?(SimpleForm::FormBuilder)
+      end
+    end)
+  end
 end

--- a/test/support/custom_builder.rb
+++ b/test/support/custom_builder.rb
@@ -1,0 +1,7 @@
+require "simple_form"
+
+class CustomBuilder < SimpleForm::FormBuilder
+  def input(attribute_name, options={}, &block)
+    super(attribute_name, options, &block)
+  end
+end


### PR DESCRIPTION
- builder class may be passed to simple_fields_for as an option
- simple_fields_for instantiates a builder of same class where the method is called e.g. a custom form builder
- added tests
