### PR TITLE
Added support to pass false for :collection_wrapper_tag & :item_wrapper_tag

### DIFF
--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -31,11 +31,9 @@ module SimpleForm
       #   * disabled => the value or values that should be disabled. Accepts a single
       #                 item or an array of items.
       #
-      #   * collection_wrapper_tag  => the tag to wrap the entire collection.
+      #   * collection_wrapper_tag  => the tag to wrap the entire collection. (or false to not apply one set via config)
       #                             
-      #   * item_wrapper_tag        => the tag to wrap each item in the collection.
-      #
-      #   * collection_wrapper_html => html options to apply the tag that wraps the entire colleciton
+      #   * item_wrapper_tag        => the tag to wrap each item in the collection. (or false to not apply one set via config)
       #
       def collection_radio(attribute, collection, value_method, text_method, options={}, html_options={})
         render_collection(
@@ -141,9 +139,10 @@ module SimpleForm
       end
 
       def render_collection(attribute, collection, value_method, text_method, options={}, html_options={}) #:nodoc:
-        collection_wrapper_tag         = options[:collection_wrapper_tag] || SimpleForm.collection_wrapper_tag
-        item_wrapper_tag               = options[:item_wrapper_tag] || SimpleForm.item_wrapper_tag
-        collection_wrapper_tag_options = options[:collection_wrapper_html] || {}
+        collection_wrapper_tag = options[:collection_wrapper_tag] 
+        collection_wrapper_tag = SimpleForm.collection_wrapper_tag if collection_wrapper_tag.nil?
+        item_wrapper_tag       = options[:item_wrapper_tag] 
+        item_wrapper_tag       = SimpleForm.item_wrapper_tag if item_wrapper_tag.nil?
 
         rendered_collection = collection.map do |item|
           value = value_for_collection(item, value_method)
@@ -155,7 +154,7 @@ module SimpleForm
           item_wrapper_tag ? @template.content_tag(item_wrapper_tag, rendered_item) : rendered_item
         end.join.html_safe
 
-        collection_wrapper_tag ? @template.content_tag(collection_wrapper_tag, rendered_collection, collection_wrapper_tag_options) : rendered_collection
+        collection_wrapper_tag ? @template.content_tag(collection_wrapper_tag, rendered_collection) : rendered_collection
       end
 
       def value_for_collection(item, value) #:nodoc:

--- a/test/inputs_test.rb
+++ b/test/inputs_test.rb
@@ -664,9 +664,16 @@ class InputTest < ActionView::TestCase
     assert_no_select 'select[required]'
   end
   
-  test 'collection input with wrapper should accept html options' do
-    with_input_for @user, :name, :radio, :collection => ['Jose', 'Carlos'], :collection_wrapper_tag => :ul, :item_wrapper_tag => :li, :collection_wrapper_html => {:class => 'foo', :id => 'bar'}
-    assert_select 'ul.foo#bar'
+  test 'collection input with collection_wrapper_tag set in config should be able to be removed by passing false' do
+    SimpleForm.collection_wrapper_tag = :ul
+    with_input_for @user, :name, :radio, :collection => ['Jose', 'Carlos'], :collection_wrapper_tag => false
+    assert_no_select 'ul'
+  end
+  
+  test 'collection input with item_wrapper_tag set in config should be able to be removed by passing false' do
+    SimpleForm.item_wrapper_tag = :li
+    with_input_for @user, :name, :radio, :collection => ['Jose', 'Carlos'], :item_wrapper_tag => false
+    assert_no_select 'li'
   end
 
   # With no object


### PR DESCRIPTION
Support the option of giving `false` to the `:collection_wrapper_tag` & `:item_wrapper_tag` to not generate wrappers when configured as default. This allows you to write situation specific HTML instead, for example:

`config/initializers/simple_form.rb`

```
SimpleForm.setup do |config|
    config.collection_wrapper_tag = :ul
    config.item_wrapper_tag = :li
end
```

Then in the view:
    <ul id="bar" class="foo">
      f.input :name, :as => :radio, :collection => ['Jose', 'Carlos'], :collection_wrapper_tag => false, :wrapper => false
    </ul>
