### PR TITLE
Default step of "any" for number input

### DIFF
--- a/lib/simple_form/inputs/numeric_input.rb
+++ b/lib/simple_form/inputs/numeric_input.rb
@@ -4,7 +4,7 @@ module SimpleForm
       def input
         input_html_options[:type] ||= "number"
         input_html_options[:size] ||= SimpleForm.default_input_size
-        input_html_options[:step] ||= 1 if integer?
+        input_html_options[:step] ||= integer? ? 1 : "any"
         infer_attributes_from_validations!
         @builder.text_field(attribute_name, input_html_options)
       end

--- a/test/inputs_test.rb
+++ b/test/inputs_test.rb
@@ -276,9 +276,9 @@ class InputTest < ActionView::TestCase
     assert_select 'input[max=119]'
   end
 
-  test 'input should infer step value only from integer attribute' do
+  test 'input should have step value of any except for integer attribute' do
     with_input_for @validating_user, :age, :float
-    assert_no_select 'input[step]'
+    assert_select 'input[step="any"]'
 
     with_input_for @validating_user, :age, :integer
     assert_select 'input[step=1]'


### PR DESCRIPTION
The default settings for an input of type numer is that it only accepts Integer. Most of the browsers fall back and don't validate this setting, except Chrome.

The valid syntax if you're not validating what type of number is setting `step="any"` otherwise it only accepts integers.
