### PR TITLE
Added ability to apply wrapper tag (and class) via config for the actual form input

### DIFF
--- a/lib/generators/simple_form/templates/simple_form.rb
+++ b/lib/generators/simple_form/templates/simple_form.rb
@@ -33,6 +33,12 @@ SimpleForm.setup do |config|
 
   # CSS class to add to all wrapper tags.
   # config.wrapper_class = :input
+  
+  # You can wrap the actual inputs in a pre-defined tag. Default is nothing.
+  # config.input_wrapper_tag = nil
+  
+  # CSS class to add to input wrapper tags. Default is input_field
+  # config.input_wrapper_class = :input_field
 
   # CSS class to add to the wrapper if the field has errors.
   # config.wrapper_error_class = :field_with_errors

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -70,6 +70,14 @@ module SimpleForm
   # You can define the class to use on all wrappers. Default is input.
   mattr_accessor :wrapper_class
   @@wrapper_class = :input
+  
+  # You can wrap the actual inputs in a pre-defined tag. Default is nothing.
+  mattr_accessor :input_wrapper_tag
+  @@input_wrapper_tag = nil
+  
+  # You can define the class to use on the wrapper around the actual inputs. Default is input_field.
+  mattr_accessor :input_wrapper_class
+  @@input_wrapper_class = :input_field
 
   # You can define the class to add to the wrapper when the field has errors. Default is field_with_errors.
   mattr_accessor :wrapper_error_class

--- a/lib/simple_form/components/label_input.rb
+++ b/lib/simple_form/components/label_input.rb
@@ -6,8 +6,14 @@ module SimpleForm
       end
 
       def label_input
-        (options[:label] == false ? "" : label) + input
+        the_label = (options[:label] == false ? '' : label)
+        if SimpleForm.input_wrapper_tag.nil?
+          the_label + input
+        else
+          the_label + template.content_tag(SimpleForm.input_wrapper_tag, input, :class => SimpleForm.input_wrapper_class)
+        end
       end
+      
     end
   end
 end

--- a/test/form_builder_test.rb
+++ b/test/form_builder_test.rb
@@ -376,6 +376,27 @@ class FormBuilderTest < ActionView::TestCase
     with_form_for @user, :name
     assert_select 'form div.input.required.string.field_with_errors'
   end
+  
+  test 'builder support wrapping inputs with a specific tag' do
+    swap SimpleForm, :input_wrapper_tag => :div do
+      with_form_for @user, :name
+      assert_select 'form div.input div>input#user_name.string'
+    end
+  end
+  
+  test 'builder inputs wrapper tag adds default css class' do
+    swap SimpleForm, :input_wrapper_tag => :div do
+      with_form_for @user, :name
+      assert_select 'form div.input div.input_field>input#user_name.string'
+    end
+  end
+  
+  test 'builder inputs wrapper tag css class can be set via config' do
+    swap SimpleForm, :input_wrapper_tag => :div, :input_wrapper_class => 'foo' do
+      with_form_for @user, :name
+      assert_select 'form div.input div.foo>input#user_name.string'
+    end
+  end
 
   # WITHOUT OBJECT
   test 'builder should generate properly when object is not present' do


### PR DESCRIPTION
Adds two new options to the config:
    # You can wrap the actual inputs in a pre-defined tag. Default is nothing.
    # config.input_wrapper_tag = nil

```
# CSS class to add to input wrapper tags. Default is input_field
# config.input_wrapper_class = :input_field
```

This allows you to set the `input_wrapper_tag` to say `span` and get the following output from simple_form:

```
<div class="input">
     <label>...</label>
     <span class="input_field"><input type="text" ... /></span>
</div>
```

I've seen this being asked a couple of times on the google group ([1](http://groups.google.com/group/plataformatec-simpleform/browse_thread/thread/981b45e0e3df3516/256af9cf8bd0863b?lnk=gst&q=wrap+input#256af9cf8bd0863b), [2](http://groups.google.com/group/plataformatec-simpleform/browse_thread/thread/10124aae20771ffa/cca4ef706267b44a?lnk=gst&q=wrap+input#cca4ef706267b44a)) and we needed to do it because we are using a CSS grid to lay out our form, however the grid uses % based widths, so we can't get text fields & textareas to line up nicely with the gird (as they have borders & padding).

Adding a wrapper around the inputs means that we use this `<span class="input_field">` to do the grid alignment, then the inputs themselves can have any padding or borders they like.
