### PR TITLE
Fixed a bug in the MapType module

### DIFF
--- a/lib/simple_form/inputs/collection_input.rb
+++ b/lib/simple_form/inputs/collection_input.rb
@@ -14,7 +14,6 @@ module SimpleForm
 
       def input
         label_method, value_method = detect_collection_methods
-
         @builder.send(:"collection_#{input_type}", attribute_name, collection,
                       value_method, label_method, input_options, input_html_options)
       end

--- a/lib/simple_form/map_type.rb
+++ b/lib/simple_form/map_type.rb
@@ -10,7 +10,7 @@ module SimpleForm
     def map_type(*types)
       map_to = types.extract_options![:to]
       raise ArgumentError, "You need to give :to as option to map_type" unless map_to
-      types.each { |t| mappings[t] = map_to }
+      self.mappings = mappings.merge types.each_with_object({}) { |t, m| m[t] = map_to }
     end
   end
 end

--- a/test/action_view_extensions/builder_test.rb
+++ b/test/action_view_extensions/builder_test.rb
@@ -1,11 +1,6 @@
 require 'test_helper'
 
-class BuilderTest < ActionView::TestCase
-
-  def with_concat_form_for(object, &block)
-    concat form_for(object, &block)
-  end
-
+class BuilderTest < ActionView::TestCase    
   def with_custom_form_for(object, *args, &block)
     with_concat_custom_form_for(object) do |f|
       assert f.instance_of?(CustomFormBuilder)
@@ -24,7 +19,7 @@ class BuilderTest < ActionView::TestCase
       f.collection_check_boxes attribute, collection, value_method, text_method, options, html_options
     end
   end
-
+  
   # COLLECTION RADIO
   test 'collection radio accepts a collection and generate inputs from value method' do
     with_collection_radio @user, :active, [true, false], :to_s, :to_s
@@ -296,4 +291,22 @@ class BuilderTest < ActionView::TestCase
       end
     end
   end
+
+  test 'form with CustomMapTypeFormBuilder should use custom map type builder' do
+    with_concat_custom_mapping_form_for(:user) do |user|
+      assert user.instance_of?(CustomMapTypeFormBuilder)
+    end
+  end
+  
+  test 'form with CustomMapTypeFormBuilder should use custom mapping' do
+    with_concat_custom_mapping_form_for(:user) do |user|
+      assert_equal SimpleForm::Inputs::StringInput, user.class.mappings[:custom_type]
+    end
+  end
+  
+  test 'form without CustomMapTypeFormBuilder should not use custom mapping' do
+    with_concat_form_for(:user) do |user|
+      assert_equal nil, user.class.mappings[:custom_type]
+    end
+  end  
 end

--- a/test/support/misc_helpers.rb
+++ b/test/support/misc_helpers.rb
@@ -36,10 +36,22 @@ module MiscHelpers
   def custom_form_for(object, *args, &block)
     simple_form_for(object, *(args << { :builder => CustomFormBuilder }), &block)
   end
+
+  def custom_mapping_form_for(object, *args, &block)
+    simple_form_for(object, *(args << { :builder => CustomMapTypeFormBuilder }), &block)
+  end
+  
+  def with_concat_custom_mapping_form_for(object, &block)
+    concat custom_mapping_form_for(object, &block)
+  end
 end
 
 class CustomFormBuilder < SimpleForm::FormBuilder
   def input(attribute_name, *args, &block)
     super(attribute_name, *(args << { :input_html => { :class => 'custom' } }), &block)
   end
+end
+
+class CustomMapTypeFormBuilder < SimpleForm::FormBuilder
+  map_type :custom_type, :to => SimpleForm::Inputs::StringInput
 end


### PR DESCRIPTION
Hey SimpleForm team!

The <code>MapType</code> module uses a class attribute to store the type mappings. When a subclass is made of <code>FormBuilder</code>, the hash in the class attribute is references by both the <code>FormBuilder</code> class and the new subclass. So; adding a type mapping to the subclass adds it to the superclass mappings as well.

I have added tests for this and proposed a fix, which creates a new hash when adding a new type mapping.

Thanks,
Roel
