### PR TITLE
Issue 224: Added config option to disable browser validations

### DIFF
--- a/lib/generators/simple_form/templates/simple_form.rb
+++ b/lib/generators/simple_form/templates/simple_form.rb
@@ -4,6 +4,9 @@ SimpleForm.setup do |config|
   # any of them, change the order, or even add your own components to the stack.
   # config.components = [ :placeholder, :label_input, :hint, :error ]
 
+  # Allow browsers to use default validations.
+  # config.disable_browser_validations = false
+
   # Default tag used on hints.
   # config.hint_tag = :span
 

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -11,6 +11,11 @@ module SimpleForm
   autoload :Inputs,            'simple_form/inputs'
   autoload :MapType,           'simple_form/map_type'
 
+
+  # Allow browsers to use default validations.
+  mattr_accessor :disable_browser_validations
+  @@disable_browser_validations = false
+
   # Default tag used on hints.
   mattr_accessor :hint_tag
   @@hint_tag = :span

--- a/lib/simple_form/action_view_extensions/form_helper.rb
+++ b/lib/simple_form/action_view_extensions/form_helper.rb
@@ -40,6 +40,7 @@ module SimpleForm
               else dom_class(record_or_name_or_array)
             end
             options[:html] ||= {}
+            options[:html][:novalidate] = SimpleForm.disable_browser_validations
             options[:html][:class] = "\#{SimpleForm.form_class} \#{css_class} \#{options[:html][:class]}".strip
 
             with_custom_field_error_proc do

--- a/test/action_view_extensions/form_helper_test.rb
+++ b/test/action_view_extensions/form_helper_test.rb
@@ -13,6 +13,18 @@ class FormHelperTest < ActionView::TestCase
     assert_select 'form.simple_form'
   end
 
+  test 'simple form should not use default browser validations if specified in the configuration options' do
+    SimpleForm.disable_browser_validations = true
+    concat(simple_form_for(:user) do |f| end)
+    assert_select 'form[novalidate="novalidate"]'
+  end
+
+  test 'simple form should use default browser validations by default' do
+    SimpleForm.disable_browser_validations = false
+    concat(simple_form_for(:user) do |f| end)
+    assert_select 'form[novalidate="novalidate"]', false
+  end
+
   test 'simple form should add object name as css class to form when object is not present' do
     concat(simple_form_for(:user) do |f| end)
     assert_select 'form.simple_form.user'


### PR DESCRIPTION
Pretty basic. Just changed <tt>lib/simple_form.rb</tt> and  <tt>lib/generators/simple_form/templates/simple_form.rb</tt> to include a new config option:

```
 config.disable_browser_validations = false
```

And added one line to <tt>lib/simple_form/action_view_extensions/form_helper.rb</tt> to use the new option:

```
options[:html][:novalidate] = SimpleForm.disable_browser_validations
```

Finally, added a couple simple tests to <tt>test/action_view_extensions/form_helper_test.rb</tt>.

See related issue: https://github.com/plataformatec/simple_form/issues#issue/224
