### PR TITLE
Failing test for nested has_many i18n lookup

### DIFF
--- a/test/components/label_test.rb
+++ b/test/components/label_test.rb
@@ -132,6 +132,25 @@ class LabelTest < ActionView::TestCase
       assert_select 'label[for=user_company_attributes_name]', /Nome da empresa/
     end
   end
+  
+  test 'label should do correct i18n lookup for nested has_many models with no nested translation' do
+    @user.tags = [Tag.new(1, 'Empresa')]
+    
+    store_translations(:en, :simple_form => { :labels => {
+      :user    => { :name => 'Usuario' },
+      :tag => { :name => 'Nome da empresa' }
+    } } ) do
+      with_concat_form_for @user do |f|
+        concat f.input :name
+        concat(f.simple_fields_for(:tags) do |tags_form|
+          concat(tags_form.input :name)
+        end)
+      end
+
+      assert_select 'label[for=user_name]', /Usuario/
+      assert_select 'label[for=user_tags_attributes_0_name]', /Nome da empresa/
+    end
+  end
 
   test 'label should have css class from type' do
     with_label_for @user, :name, :string

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -39,7 +39,7 @@ class User
   include ActiveModel::Conversion
 
   attr_accessor :id, :name, :company, :company_id, :time_zone, :active, :description, :created_at, :updated_at,
-    :credit_limit, :age, :password, :delivery_time, :born_at, :special_company_id, :country, :url, :tag_ids,
+    :credit_limit, :age, :password, :delivery_time, :born_at, :special_company_id, :country, :url, :tags, :tag_ids,
     :avatar, :home_picture, :email, :status, :residence_country, :phone_number, :post_count, :lock_version,
     :amount, :attempts
 
@@ -58,6 +58,9 @@ class User
   end
 
   def company_attributes=(*)
+  end
+  
+  def tags_attributes=(*)
   end
 
   def column_for_attribute(attribute)


### PR DESCRIPTION
I've added a failing test for the i18n lookup of nested has_many models. The lookup will succeed if:

:tag => { :name => 'Nome da empresa' } 
is changed to 
:tags => { :name => 'Nome da empresa' }

but will fail again if:

f.simple_fields_for(:tags) 
is changed to 
f.simple_fields_for(:tags, :child_index => 'new_tag')

Maybe I'm just confused about how the lookup is supposed to work?
