### PR TITLE
Display errors assigned to :base

### DIFF
--- a/lib/simple_form/error_notification.rb
+++ b/lib/simple_form/error_notification.rb
@@ -1,6 +1,6 @@
 module SimpleForm
   class ErrorNotification
-    delegate :object, :object_name, :template, :to => :@builder
+    delegate :object, :object_name, :template, :error, :to => :@builder
     include SimpleForm::HasErrors
 
     def initialize(builder, options)
@@ -11,7 +11,7 @@ module SimpleForm
 
     def render
       if has_errors?
-        template.content_tag(error_notification_tag, error_message, html_options)
+        template.content_tag(error_notification_tag, error_message, html_options) + error(:base)
       end
     end
 

--- a/test/error_notification_test.rb
+++ b/test/error_notification_test.rb
@@ -25,6 +25,12 @@ class ErrorNotificationTest < ActionView::TestCase
     assert_select 'p.error_notification', 'Some errors were found, please take a look:'
   end
 
+  test "error notification prints message for error on :base" do
+    @validating_user.errors.add :base, "too many users"
+    with_error_notification_for @validating_user
+    assert_select 'span.error', "too many users"
+  end
+
   test 'error notification uses I18n based on model to generate the notification message' do
     store_translations(:en, :simple_form => { :error_notification => { :user =>
       'Alguns erros foram encontrados para o usuário:'


### PR DESCRIPTION
When assigning error messages to `errors[:base]` as suggested in the Rails documentation, we want those to appear on the form.

I made `ErrorNotification` responsible for printing these, but didn't put the messages inside the error notification tag, just appended them. Not sure what the preferred place for them is.
