### PR TITLE
Ability to set hint text to html_safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .bundle/
 pkg/
+*.swp
+**/*.swp

--- a/lib/generators/simple_form/templates/simple_form.rb
+++ b/lib/generators/simple_form/templates/simple_form.rb
@@ -10,6 +10,10 @@ SimpleForm.setup do |config|
   # CSS class to add to all hint tags.
   # config.hint_class = :hint
 
+  # Default html safeness of hints
+  # Setting this to true will render all hints as HTML
+  # config.hint_html_safe = false
+
   # CSS class used on errors.
   # config.error_class = :error
 

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -19,6 +19,11 @@ module SimpleForm
   mattr_accessor :hint_class
   @@hint_class = :hint
 
+  # Default hint html safeness
+  # Setting this to true will render hints as HTML
+  mattr_accessor :hint_html_safe
+  @@hint_html_safe = false
+
   # Default tag used on errors.
   mattr_accessor :error_tag
   @@error_tag = :span

--- a/lib/simple_form/components/hints.rb
+++ b/lib/simple_form/components/hints.rb
@@ -11,6 +11,12 @@ module SimpleForm
 
       def hint_text
         @hint_text ||= options[:hint] || translate(:hints)
+        # options[:hint_html_safe] is true OR (options[:hint_html_safe] was not defined AND SimpleForm.hint_html_safe is true)
+        if options[:hint_html_safe] || (options[:hint_html_safe].nil? && SimpleForm.hint_html_safe)
+          @hint_text.try(:html_safe)
+        else
+          @hint_text
+        end
       end
 
       def hint_html_options

--- a/test/components/hint_test.rb
+++ b/test/components/hint_test.rb
@@ -71,4 +71,14 @@ class HintTest < ActionView::TestCase
     with_hint_for @user, :name, :string, :hint => 'Yay!', :hint_html => { :id => 'hint', :class => 'yay' }
     assert_select 'span#hint.hint.yay'
   end
+
+  test 'hint should be able to render HTML when hint_html_safe == true' do
+    with_hint_for @user, :name, :string, :hint => '<span id="inner_hint">Inside</span>', :hint_html_safe => true
+    assert_select 'span span#inner_hint'
+  end
+
+  test 'hint should not render HTML when hint_html_safe == false or nil' do
+    with_hint_for @user, :name, :string, :hint => '<span id="inner_hint">Inside</span>'
+    assert_no_select 'span span#inner_hint'
+  end
 end

--- a/test/inputs_test.rb
+++ b/test/inputs_test.rb
@@ -411,6 +411,20 @@ class InputTest < ActionView::TestCase
     end
   end
 
+  test 'when SimpleForm.hint_html_safe = false but overriden by view options[:hint_html_safe] = true' do
+    swap SimpleForm, :hint_html_safe => false do
+      with_input_for @user, :name, :string, :hint => '<span id="inner_hint">Inner</span>', :hint_html_safe => true
+      assert_select 'span span#inner_hint'
+    end
+  end
+
+  test 'when SimpleForm.hint_html_safe = true and view options[:hint_html_safe] was not defined' do
+    swap SimpleForm, :hint_html_safe => true do
+      with_input_for @user, :name, :string, :hint => '<span id="inner_hint">Inner</span>'
+      assert_select 'span span#inner_hint'
+    end
+  end
+
   # HiddenInput
   test 'input should generate a hidden field' do
     with_input_for @user, :name, :hidden


### PR DESCRIPTION
Sometimes you may want a pre tag, a code tag, or links in the hint. It's false by default. You can set it to true two ways:
1. pass :hint_html_safe => true in the view. This overrides whatever setting you put in SimpleForm setup

```
f.input :name, :hint => "It will look like this: <pre>awesome</pre>", :hint_html_safe => true
```
1. Do it through SimpleForm.setup (I've added it to the generator, and simple_form.rb)
