### PR TITLE
Made input type class optional for labels

### DIFF
--- a/lib/generators/simple_form/templates/simple_form.rb
+++ b/lib/generators/simple_form/templates/simple_form.rb
@@ -52,6 +52,9 @@ SimpleForm.setup do |config|
   # How the label text should be generated altogether with the required text.
   # config.label_text = lambda { |label, required| "#{required} #{label}" }
 
+  # You can set whether or not the label includes the input type in it's class.
+  # config.include_type_in_label_class = true
+
   # You can define the class to use on all labels. Default is nil.
   # config.label_class = nil
 

--- a/lib/simple_form/components/labels.rb
+++ b/lib/simple_form/components/labels.rb
@@ -36,7 +36,9 @@ module SimpleForm
       end
 
       def label_html_options
-        label_options = html_options_for(:label, [input_type, required_class, SimpleForm.label_class])
+        classes = [required_class, SimpleForm.label_class]
+        classes << input_type if SimpleForm.include_type_in_label_class
+        label_options = html_options_for(:label, classes)
         label_options[:for] = options[:input_html][:id] if options.key?(:input_html) && options[:input_html].key?(:id)
         label_options
       end

--- a/test/components/label_test.rb
+++ b/test/components/label_test.rb
@@ -153,16 +153,18 @@ class LabelTest < ActionView::TestCase
   end
 
   test 'label should have css class from type' do
-    with_label_for @user, :name, :string
-    assert_select 'label.string'
-    with_label_for @user, :description, :text
-    assert_select 'label.text'
-    with_label_for @user, :age, :integer
-    assert_select 'label.integer'
-    with_label_for @user, :born_at, :date
-    assert_select 'label.date'
-    with_label_for @user, :created_at, :datetime
-    assert_select 'label.datetime'
+    if SimpleForm.include_type_in_label_class
+      with_label_for @user, :name, :string
+      assert_select 'label.string'
+      with_label_for @user, :description, :text
+      assert_select 'label.text'
+      with_label_for @user, :age, :integer
+      assert_select 'label.integer'
+      with_label_for @user, :born_at, :date
+      assert_select 'label.date'
+      with_label_for @user, :created_at, :datetime
+      assert_select 'label.datetime'
+    end
   end
 
   test 'label should obtain required from ActiveModel::Validations when it is included' do


### PR DESCRIPTION
Title says it all.  I had a use in which I didn't want the input type as a class on the label tags, so I made it optional.
