### PR TITLE
Adding mongoid as a supported ORM.

### DIFF
--- a/lib/generators/simple_form/install_generator.rb
+++ b/lib/generators/simple_form/install_generator.rb
@@ -4,9 +4,10 @@ module SimpleForm
       desc "Copy SimpleForm default files"
       source_root File.expand_path('../templates', __FILE__)
       class_option :template_engine
+      class_option :orm
 
       def copy_initializers
-        copy_file 'simple_form.rb', 'config/initializers/simple_form.rb'
+        template 'simple_form.rb', 'config/initializers/simple_form.rb'
       end
 
       def copy_locale_file

--- a/lib/generators/simple_form/templates/simple_form.rb
+++ b/lib/generators/simple_form/templates/simple_form.rb
@@ -1,5 +1,10 @@
 # Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
+  # ==> ORM Configuration
+  # Load and configure the ORM. Supports :active_record default.
+  # Other ORMs: :mongoid.
+  require 'simple_form/orm/<%= options[:orm] %>'
+
   # Components used by the form builder to generate a complete input. You can remove
   # any of them, change the order, or even add your own components to the stack.
   # config.components = [ :placeholder, :label_input, :hint, :error ]

--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -152,28 +152,23 @@ module SimpleForm
       options[:as] ||= :select
       options[:collection] ||= reflection.klass.all(reflection.options.slice(:conditions, :order))
 
-      attribute = case reflection.macro
-        when :belongs_to
-          reflection.options[:foreign_key] || :"#{reflection.name}_id"
-        when :has_one
-          raise ":has_one associations are not supported by f.association"
-        else
-          if options[:as] == :select
-            html_options = options[:input_html] ||= {}
-            html_options[:size]   ||= 5
-            html_options[:multiple] = true unless html_options.key?(:multiple)
-          end
+      attribute = find_attribute_column_by_reflection reflection
 
-          # Force the association to be preloaded for performance.
-          if options[:preload] != false && object.respond_to?(association)
-            target = object.send(association)
-            target.to_a if target.respond_to?(:to_a)
-          end
-
-          :"#{reflection.name.to_s.singularize}_ids"
+      if options[:as] == :select
+        html_options = options[:input_html] ||= {}
+        html_options[:size]   ||= 5
+        html_options[:multiple] = true unless html_options.key?(:multiple)
       end
 
+      preload_association_for_performance options, object, association
       input(attribute, options.merge(:reflection => reflection))
+    end
+
+    def preload_association_for_performance options, object, association
+      if options[:preload] != false && object.respond_to?(association)
+        target = object.send(association)
+        target.to_a if target.respond_to?(:to_a)
+      end
     end
 
     # Creates a button:

--- a/lib/simple_form/orm/active_record.rb
+++ b/lib/simple_form/orm/active_record.rb
@@ -1,0 +1,18 @@
+module SimpleForm
+  module Orm
+    module ActiveRecord
+      def find_attribute_column_by_reflection reflection
+        case reflection.macro
+        when :belongs_to
+          reflection.options[:foreign_key] || :"#{reflection.name}_id"
+        when :has_one
+          raise ":has_one associations are not supported by f.association"
+        else
+          :"#{reflection.name.to_s.singularize}_ids"
+        end
+      end
+    end
+  end
+end
+
+SimpleForm::FormBuilder.send :include, SimpleForm::Orm::ActiveRecord

--- a/lib/simple_form/orm/mongoid.rb
+++ b/lib/simple_form/orm/mongoid.rb
@@ -1,0 +1,20 @@
+module SimpleForm
+  module Orm
+    module Mongoid
+      def find_attribute_column_by_reflection reflection
+        case reflection.relation.macro
+        when :embedded_in, :embeds_one
+          :"#{reflection.name.to_s.singularize}"
+        when :referenced_in, :references_one
+          :"#{reflection.name.to_s.singularize}_id"
+        when :embeds_many
+          :"#{reflection.name.to_s.pluralize}"
+        else
+          :"#{reflection.name.to_s.singularize}_ids"
+        end
+      end
+    end
+  end
+end
+
+SimpleForm::FormBuilder.send :include, SimpleForm::Orm::Mongoid

--- a/test/orm/mongoid_test.rb
+++ b/test/orm/mongoid_test.rb
@@ -1,0 +1,84 @@
+require 'simple_form/orm/mongoid'
+require 'test_helper'
+
+class MongoidForm
+  include SimpleForm::Orm::Mongoid
+end
+
+# TODO: Use relations from actual Mongoid.
+module Mongoid
+  module Relations
+    module Referenced
+      class In
+        def macro; :referenced_in; end
+      end
+      class One
+        def macro; :references_one; end
+      end
+      class Many
+        def macro; :references_many; end
+      end
+    end
+    module Embedded
+      class In
+        def macro; :embedded_in; end
+      end
+      class One
+        def macro; :embeds_one; end
+      end
+      class Many
+        def macro; :embeds_many; end
+      end
+    end
+  end
+end
+
+class MongoidTest < Test::Unit::TestCase
+  def test_belongs_to_returns_singular_id
+    reflection = Object.new
+    reflection.expects(:name).returns("door")
+    reflection.expects(:relation).returns Mongoid::Relations::Referenced::In.new
+    result = MongoidForm.new.find_attribute_column_by_reflection reflection
+    assert_equal :door_id, result
+  end
+
+  def test_has_one_returns_singular_id
+    reflection = Object.new
+    reflection.expects(:name).returns("door")
+    reflection.expects(:relation).returns Mongoid::Relations::Referenced::One.new
+    result = MongoidForm.new.find_attribute_column_by_reflection reflection
+    assert_equal :door_id, result
+  end
+
+  def test_has_many_returns_singular_ids
+    reflection = Object.new
+    reflection.expects(:name).returns("doors")
+    reflection.expects(:relation).returns Mongoid::Relations::Referenced::Many.new
+    result = MongoidForm.new.find_attribute_column_by_reflection reflection
+    assert_equal :door_ids, result
+  end
+
+  def test_embedded_in_returns_singular
+    reflection = Object.new
+    reflection.expects(:name).returns("door")
+    reflection.expects(:relation).returns Mongoid::Relations::Embedded::In.new
+    result = MongoidForm.new.find_attribute_column_by_reflection reflection
+    assert_equal :door, result
+  end
+
+  def test_embedds_one_returns_singular
+    reflection = Object.new
+    reflection.expects(:name).returns("door")
+    reflection.expects(:relation).returns Mongoid::Relations::Embedded::One.new
+    result = MongoidForm.new.find_attribute_column_by_reflection reflection
+    assert_equal :door, result
+  end
+
+  def test_embeds_many_returns_plural
+    reflection = Object.new
+    reflection.expects(:name).returns("doors")
+    reflection.expects(:relation).returns Mongoid::Relations::Embedded::Many.new
+    result = MongoidForm.new.find_attribute_column_by_reflection reflection
+    assert_equal :doors, result
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,8 +21,11 @@ end
 
 $:.unshift File.expand_path("../../lib", __FILE__)
 require 'simple_form'
+require 'simple_form/orm/mongoid'
+require 'simple_form/orm/active_record'
 
 Dir["#{File.dirname(__FILE__)}/support/*.rb"].each { |f| require f }
+Dir["#{File.dirname(__FILE__)}/orm/*.rb"].each { |f| require f }
 I18n.default_locale = :en
 
 country_select = "#{File.dirname(__FILE__)}/support/country_select/lib"


### PR DESCRIPTION
ORM to create correct simple_form initializer. Extract
the ORM-specific code into modules that the initializer
will use.
Extraction code inspired by Rafael Franca's initial PR.

Tested for Rails 3.0.9 and Mongoid 2.0
