### PR TITLE
Marking a field as required when it has alternative validations

### DIFF
--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -18,7 +18,7 @@ module SimpleForm
       attr_reader :attribute_name, :column, :input_type, :reflection,
                   :options, :input_html_options
 
-      delegate :template, :object, :object_name, :to => :@builder
+      delegate :template, :object, :object_name, :required_fields, :to => :@builder
 
       def initialize(builder, attribute_name, column, input_type, options = {})
         @builder            = builder
@@ -65,10 +65,8 @@ module SimpleForm
       def attribute_required?
         if !options[:required].nil?
           options[:required]
-        elsif has_validators?
-          (attribute_validators + reflection_validators).any? do |v|
-						[ :presence, :length, :format, :inclusion, :exclusion, :numericality ].include?(v.kind) && !conditional_validators?(v) && validator_excludes_empty_strings?(v)
-          end
+        elsif required_fields.include?(attribute_name)
+					true
         else
           attribute_required_by_default?
         end
@@ -83,64 +81,13 @@ module SimpleForm
         options[:autofocus]
       end
 
-      def has_validators?
-        attribute_name && object.class.respond_to?(:validators_on)
-      end
+			def has_validators?
+				attribute_name && object.class.respond_to?(:validators_on)
+			end
 
-      def validator_excludes_empty_strings?(validator)
-				case validator.kind
-        when :length
-					return false if validator.options[:allow_nil]
-					return false if validator.options[:allow_blank]
-          return validator.options[:is] != 0 if validator.options.has_key?(:is)
-          return validator.options[:minimum] > 0 if validator.options.has_key?(:minimum)
-          return false
-        when :format
-					return false if validator.options[:allow_nil]
-					return false if validator.options[:allow_blank]
-          return false if validator.options[:with] && "" =~ validator.options[:with]
-          return false if validator.options[:without] && "" !~ validator.options[:without]
-          return true
-        when :presence
-          return true
-        when :inclusion
-					return false if validator.options[:allow_nil]
-					return false if validator.options[:allow_blank]
-					enum = validator.options[:in]
-					inclusions = enum.respond_to?(:call) ? enum.call(object) : enum
-          if inclusions.is_a?(Range)
-            return !inclusions.cover?("")
-          else
-            return !inclusions.include?("")
-          end
-        when :exclusion
-					return false if validator.options[:allow_nil]
-					return false if validator.options[:allow_blank]
-					enum = validator.options[:in]
-					exclusions = enum.respond_to?(:call) ? enum.call(object) : enum
-          if exclusions.is_a?(Range)
-            return exclusions.cover?("")
-          else
-            return exclusions.include?("")
-          end
-				when :numericality
-					return !validator.options[:allow_nil]
-        else
-          return false
-        end
-      end
-
-      def attribute_validators
-        object.class.validators_on(attribute_name)
-      end
-
-      def reflection_validators
-        reflection ? object.class.validators_on(reflection.name) : []
-      end
-
-      def conditional_validators?(validator)
-        validator.options.include?(:if) || validator.options.include?(:unless)
-      end
+			def attribute_validators
+				object.class.validators_on(attribute_name)
+			end
 
       def attribute_required_by_default?
         SimpleForm.required_by_default

--- a/test/support/misc_helpers.rb
+++ b/test/support/misc_helpers.rb
@@ -55,3 +55,17 @@ end
 class CustomMapTypeFormBuilder < SimpleForm::FormBuilder
   map_type :custom_type, :to => SimpleForm::Inputs::StringInput
 end
+
+module AttributeNamesMethods
+	def attr_accessor(*attrs)
+		@attributes ||= []
+		attrs.each do |a|
+			@attributes << a
+			super(a)
+		end
+	end
+
+	def attributes
+		@attributes || []
+	end
+end

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -6,6 +6,8 @@ Association = Struct.new(:klass, :name, :macro, :options)
 class Company < Struct.new(:id, :name)
   extend ActiveModel::Naming
   include ActiveModel::Conversion
+  include ActiveModel::Validations
+	include AttributeNamesMethods
 
   def self.all(options={})
     all = (1..3).map{|i| Company.new(i, "Company #{i}")}
@@ -23,6 +25,7 @@ class Company < Struct.new(:id, :name)
   def persisted?
     true
   end
+
 end
 
 class Tag < Company
@@ -37,6 +40,8 @@ end
 class User
   extend ActiveModel::Naming
   include ActiveModel::Conversion
+  include ActiveModel::Validations
+	include AttributeNamesMethods
 
   attr_accessor :id, :name, :company, :company_id, :time_zone, :active, :age,
     :description, :created_at, :updated_at, :credit_limit, :password, :url,
@@ -124,7 +129,6 @@ class User
 end
 
 class ValidatingUser < User
-  include ActiveModel::Validations
   validates :name, :presence => true
   validates :company, :presence => true
   validates :age, :presence => true, :if => Proc.new { |user| user.name }
@@ -160,7 +164,6 @@ class ValidatingUser < User
 end
 
 class OtherValidatingUser < User
-  include ActiveModel::Validations
   validates_numericality_of :age,
     :greater_than => 17,
     :less_than => 100,


### PR DESCRIPTION
Hi,
This is a feature I have developed a patch for for our own organization. I was looking to share it with you in the hopes that the rest of the community can use it (and so that I don't have to maintain my own fork :-p).

Basically, it marks a field as required when it has a validates_length_of, validates_format_of, etc. provided that those requirements won't match an empty string.

I hope this is useful. Please let me know if there are any changes I can make to the code or explaination I can provide or anything that would help implement these features.

This code serves its purpose in our application, but it has not been heavily reviewed or tested.  (Let me know if I can be of help in testing as well.)

Best,
Mike Vastola
