### PR TITLE
added skip_model_class option for simple_form_for

### DIFF
--- a/lib/simple_form/action_view_extensions/form_helper.rb
+++ b/lib/simple_form/action_view_extensions/form_helper.rb
@@ -35,12 +35,12 @@ module SimpleForm
                     when String, Symbol then record.to_s
                     when Array then dom_class(record.last)
                     else dom_class(record)
-                    end
+                    end unless options[:skip_model_class]
         options[:html] ||= {}
         unless options[:html].key?(:novalidate)
           options[:html][:novalidate] = !SimpleForm.browser_validations
         end
-        options[:html][:class] = "#{SimpleForm.form_class} #{css_class} #{options[:html][:class]}".strip
+        options[:html][:class] = [SimpleForm.form_class, css_class, options[:html][:class]].compact.join(" ")
 
         with_custom_field_error_proc do
           form_for(record, options, &block)

--- a/test/action_view_extensions/form_helper_test.rb
+++ b/test/action_view_extensions/form_helper_test.rb
@@ -12,6 +12,11 @@ class FormHelperTest < ActionView::TestCase
     concat(simple_form_for(:user) do |f| end)
     assert_select 'form.simple_form'
   end
+  
+  test 'simple form should not add object class to form if skip_model_class is true' do
+    concat(simple_form_for(:user, :skip_model_class => true) do |f| end)
+    assert_no_select 'form.user'
+  end
 
   test 'simple form should use default browser validations by default' do
     concat(simple_form_for(:user) do |f| end)


### PR DESCRIPTION
Added the option to do:

simple_form_for(:alert, :skip_model_class) => true do
  ...
end

and this will give you a form without an "alert" class.
