### PR TITLE
Css class

### DIFF
--- a/lib/simple_form/action_view_extensions/form_helper.rb
+++ b/lib/simple_form/action_view_extensions/form_helper.rb
@@ -31,19 +31,24 @@ module SimpleForm
 
       def simple_form_for(record, options={}, &block)
         options[:builder] ||= SimpleForm::FormBuilder
-        css_class = case record
-                    when String, Symbol then record.to_s
-                    when Array then dom_class(record.last)
-                    else dom_class(record)
-                    end
         options[:html] ||= {}
         unless options[:html].key?(:novalidate)
           options[:html][:novalidate] = !SimpleForm.browser_validations
         end
-        options[:html][:class] = "#{SimpleForm.form_class} #{css_class} #{options[:html][:class]}".strip
-
+        options[:html][:class] = [SimpleForm.form_class, css_class(record, options[:html])].compact.join(" ")
         with_custom_field_error_proc do
           form_for(record, options, &block)
+        end
+      end
+      
+      def css_class(record, html_options)
+        if html_options.key?(:class)
+          html_options[:class]
+        elsif record.is_a?(String) || record.is_a?(Symbol)
+          record
+        else
+          record = record.last if record.is_a?(Array)
+          dom_class(record)
         end
       end
 

--- a/test/action_view_extensions/form_helper_test.rb
+++ b/test/action_view_extensions/form_helper_test.rb
@@ -46,6 +46,16 @@ class FormHelperTest < ActionView::TestCase
     concat(simple_form_for(@user) do |f| end)
     assert_select 'form.simple_form.user'
   end
+  
+  test 'simple form should not add object class to form if css_class is specified' do
+    concat(simple_form_for(:user, :html => {:class => nil}) do |f| end)
+    assert_no_select 'form.user'
+  end
+  
+  test 'simple form should add custom class to form if css_class is specified' do
+    concat(simple_form_for(:user, :html => {:class => 'my_class'}) do |f| end)
+    assert_select 'form.my_class'
+  end
 
   test 'pass options to simple form' do
     concat(simple_form_for(:user, :url => '/account', :html => { :id => 'my_form' }) do |f| end)


### PR DESCRIPTION
added css_class method which will override the default model class if the user provides a css option.  Passing in :html => {:class => nil} will result in only a "simple_form" class.
