### PR TITLE
Explicit false option for collection_wrapper_tag and item_wrapper_tag

### DIFF
--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -134,8 +134,8 @@ module SimpleForm
       end
 
       def render_collection(attribute, collection, value_method, text_method, options={}, html_options={}) #:nodoc:
-        collection_wrapper_tag = options[:collection_wrapper_tag] || SimpleForm.collection_wrapper_tag
-        item_wrapper_tag       = (defined? options[:item_wrapper_tag]) ? options[:item_wrapper_tag] : SimpleForm.item_wrapper_tag
+        collection_wrapper_tag = (options[:collection_wrapper_tag] || options[:collection_wrapper_tag] === false) ? options[:collection_wrapper_tag] : SimpleForm.collection_wrapper_tag
+        item_wrapper_tag = (options[:item_wrapper_tag] || options[:item_wrapper_tag] === false) ? options[:item_wrapper_tag] : SimpleForm.item_wrapper_tag
 
         rendered_collection = collection.map do |item|
           value = value_for_collection(item, value_method)

--- a/test/action_view_extensions/builder_test.rb
+++ b/test/action_view_extensions/builder_test.rb
@@ -96,6 +96,13 @@ class BuilderTest < ActionView::TestCase
     assert_select 'form ul input[type=radio][value=false]#user_active_false'
   end
 
+  test 'collection radio does not wrap the collection in the explicitly false collection wrapper tag' do
+    with_collection_radio @user, :active, [true, false], :to_s, :to_s, :collection_wrapper_tag => false, :item_wrapper_tag => false
+
+    assert_select 'form > input[type=radio][value=true]#user_active_true'
+    assert_select 'form > input[type=radio][value=false]#user_active_false'
+  end
+
   test 'collection radio does not wrap the collection by default' do
     with_collection_radio @user, :active, [true, false], :to_s, :to_s
 
@@ -116,6 +123,13 @@ class BuilderTest < ActionView::TestCase
 
     assert_select 'form li input[type=radio][value=true]#user_active_true'
     assert_select 'form li input[type=radio][value=false]#user_active_false'
+  end
+
+  test 'collection radio does not wrap each label/radio in the explicitly false item wrapper tag' do
+    with_collection_radio @user, :active, [true, false], :to_s, :to_s, :item_wrapper_tag => false
+
+    assert_select 'form > input[type=radio][value=true]#user_active_true'
+    assert_select 'form > input[type=radio][value=false]#user_active_false'
   end
 
   test 'collection radio wrap items in a span tag by default' do
@@ -246,6 +260,13 @@ class BuilderTest < ActionView::TestCase
     assert_select 'form ul input[type=checkbox][value=false]#user_active_false'
   end
 
+  test 'collection check box does not wrap the collection in the explicitly false collection wrapper tag' do
+    with_collection_check_boxes @user, :active, [true, false], :to_s, :to_s, :collection_wrapper_tag => false, :item_wrapper_tag => false
+
+    assert_select 'form > input[type=checkbox][value=true]#user_active_true'
+    assert_select 'form > input[type=checkbox][value=false]#user_active_false'
+  end
+
   test 'collection check box does not wrap the collection by default' do
     with_collection_check_boxes @user, :active, [true, false], :to_s, :to_s
 
@@ -266,6 +287,13 @@ class BuilderTest < ActionView::TestCase
 
     assert_select 'form li input[type=checkbox][value=true]#user_active_true'
     assert_select 'form li input[type=checkbox][value=false]#user_active_false'
+  end
+
+  test 'collection check box does not wrapp each label/radio in the explicitly false item wrapper tag' do
+    with_collection_check_boxes @user, :active, [true, false], :to_s, :to_s, :item_wrapper_tag => false
+
+    assert_select 'form > input[type=checkbox][value=true]#user_active_true'
+    assert_select 'form > input[type=checkbox][value=false]#user_active_false'
   end
 
   test 'collection check box wrap items in a span tag by default' do


### PR DESCRIPTION
Added logic that allows you to pass a value of false to :item_wrapper_tag or :collection_wrapper_tag, which renders the content without a wrapper tag. 4 tests have been for this behavior.
