### PR TITLE
Added logic that allows wrapper tag to be set explicitly to false. Added 3 tests for wrapper tag.

### DIFF
--- a/lib/simple_form/components/wrapper.rb
+++ b/lib/simple_form/components/wrapper.rb
@@ -10,7 +10,7 @@ module SimpleForm
       end
 
       def wrapper_tag
-        options[:wrapper_tag] || SimpleForm.wrapper_tag
+        (options[:wrapper_tag] || options[:wrapper_tag] === false) ? options[:wrapper_tag] : SimpleForm.wrapper_tag
       end
 
       def wrapper_class

--- a/test/action_view_extensions/builder_test.rb
+++ b/test/action_view_extensions/builder_test.rb
@@ -346,4 +346,27 @@ class BuilderTest < ActionView::TestCase
       end
     end
   end
+  
+  test 'fields for wraps item in the configured wrapper tag' do
+    swap SimpleForm, :wrapper_tag => :em do
+      with_concat_form_for :user do |f|
+        f.input :name
+      end
+    end
+    assert_select 'form em input'
+  end
+  
+  test 'fields for wraps item in the given wrapper tag' do
+    with_concat_form_for :user do |f|
+      f.input :name, :wrapper_tag => :em
+    end
+    assert_select 'form em input#user_name'
+  end
+  
+  test 'fields for does not wrap item in the explicitly fasle given wrapper tag' do
+    with_concat_form_for :user do |f|
+      f.input :name, :wrapper_tag => false
+    end
+    assert_select 'form > input'
+  end
 end


### PR DESCRIPTION
After recently adding functionality for explicitly false "collection wrapper tag" and "item wrapper tag", I realized that this was still missing on "wrapper tag". I wrote a simple fix for this and wrote 3 new tests that check for configured "wrapper tag", given "wrapper tag", and explicitly false "wrapper tag".
