### PR TITLE
Allow Custom Setting Of Maxlength For String Attributes

### DIFF
--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -28,6 +28,7 @@ module SimpleForm
         @reflection         = options.delete(:reflection)
         @options            = options
         @input_html_options = html_options_for(:input, input_html_classes).tap do |o|
+          o[:maxlength] = options.delete(:maxlength)
           o[:required]  = true if has_required? # Don't make this conditional on HTML5 here, because we want the CSS class to be set
           o[:disabled]  = true if disabled?
           o[:autofocus] = true if has_autofocus? && SimpleForm.html5

--- a/test/inputs_test.rb
+++ b/test/inputs_test.rb
@@ -146,6 +146,11 @@ class InputTest < ActionView::TestCase
     assert_select 'input.decimal[size=50]'
   end
 
+  test 'input should get maxlength from options before defaulting to column definition for string sttributes' do
+    with_input_for @user, :name, :string, :maxlength => 10
+    assert_select 'input.string[maxlength=10]'
+  end
+
   test 'input should get maxlength from column definition for string attributes' do
     with_input_for @user, :name, :string
     assert_select 'input.string[maxlength=100]'


### PR DESCRIPTION
Currently, method #input in SimpleForm::Inputs::StringInput does not allow custom setting of maxlength for string inputs, as it defaults to column definition. Is this a bug?

Would really like to be able to specify a desired maxlength for any string attributes when calling #input.

Please see test and code for details.

Thanks!

Cheers,
Winston
