### PR TITLE
Numeric inputs incorrectly add a 'size' attribute

### DIFF
--- a/lib/simple_form/inputs/numeric_input.rb
+++ b/lib/simple_form/inputs/numeric_input.rb
@@ -3,7 +3,7 @@ module SimpleForm
     class NumericInput < Base
       def input
         input_html_options[:type] ||= "number" if SimpleForm.html5
-        input_html_options[:size] ||= SimpleForm.default_input_size
+        input_html_options[:size] ||= nil
         input_html_options[:step] ||= integer? ? 1 : "any" if SimpleForm.html5
         infer_attributes_from_validations! if SimpleForm.html5
         @builder.text_field(attribute_name, input_html_options)

--- a/test/inputs_test.rb
+++ b/test/inputs_test.rb
@@ -141,9 +141,9 @@ class InputTest < ActionView::TestCase
     assert_select "input#user_password.password[type=password][name='user[password]']"
   end
 
-  test 'input should use default text size for decimal attributes' do
+  test 'input should not use size attribute for decimal attributes' do
     with_input_for @user, :credit_limit, :decimal
-    assert_select 'input.decimal[size=50]'
+    assert_no_select 'input.decimal[size]'
   end
 
   test 'input should get maxlength from column definition for string attributes' do


### PR DESCRIPTION
I run my view tests against an HTML5 validator and today I noticed some numeric fields were failing validation because they included a `size` value. I had to hunt to find the [relevant part of the spec](http://www.whatwg.org/specs/web-apps/current-work/multipage/number-state.html#number-state) (see the _Bookkeeping details_ section footer), but sure enough (emphasis mine):

> The following content attributes must not be specified and do not apply to the element: accept, alt, checked, dirname, formaction, formenctype, formmethod, formnovalidate, formtarget, height, maxlength, multiple, pattern, **size**, src, and width.

See the attached commit for my fix.
