### PR TITLE
Changes required to allow simple form to work with twitter bootstrap

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb
@@ -2,16 +2,16 @@
 SimpleForm.setup do |config|
   # Components used by the form builder to generate a complete input. You can remove
   # any of them, change the order, or even add your own components to the stack.
-  # config.components = [ :placeholder, :maxlength, :label_input, :hint, :error ]
+  config.components = [ :placeholder, :label_input, :hint ]
 
   # Default tag used on hints.
   # config.hint_tag = :span
 
   # CSS class to add to all hint tags.
-  # config.hint_class = :hint
+  config.hint_class = "help-inline"
 
   # CSS class used on errors.
-  # config.error_class = :error
+  config.error_class = "help-inline"
 
   # Default tag used on errors.
   # config.error_tag = :span
@@ -29,13 +29,16 @@ SimpleForm.setup do |config|
   # config.error_notification_id = nil
 
   # You can wrap all inputs in a pre-defined tag.
-  # config.wrapper_tag = :div
+  config.wrapper_tag = :div
+
+  config.input_wrapper_tag = :div
+  config.input_wrapper_class = 'input'
 
   # CSS class to add to all wrapper tags.
-  # config.wrapper_class = :input
+  config.wrapper_class = :clearfix
 
   # CSS class to add to the wrapper if the field has errors.
-  # config.wrapper_error_class = :field_with_errors
+  config.wrapper_error_class = :error
 
   # You can wrap a collection of radio/check boxes in a pre-defined tag, defaulting to none.
   # config.collection_wrapper_tag = nil

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -55,6 +55,14 @@ module SimpleForm
   mattr_accessor :collection_value_methods
   @@collection_value_methods = [ :id, :to_s ]
 
+  # Tag to wrap input element into
+  mattr_accessor :input_wrapper_tag
+  @@input_wrapper_tag = nil
+
+  # Input wrapper's class
+  mattr_accessor :input_wrapper_class
+  @@input_wrapper_class = :input_field
+
   # You can wrap a collection of radio/check boxes in a pre-defined tag, defaulting to none.
   mattr_accessor :collection_wrapper_tag
   @@collection_wrapper_tag = nil

--- a/lib/simple_form/components/label_input.rb
+++ b/lib/simple_form/components/label_input.rb
@@ -3,10 +3,18 @@ module SimpleForm
     module LabelInput
       def self.included(base)
         base.send :include, SimpleForm::Components::Labels
+        base.send :include, SimpleForm::Components::Errors
       end
 
       def label_input
-        (options[:label] == false ? "" : label) + input
+        the_label = (options[:label] == false ? '' : label)
+        the_input = (options[:components] || SimpleForm.components).include?(:error) && options[:error] && error ? input.safe_concat(error) : input
+
+        if SimpleForm.input_wrapper_tag.nil?
+          the_label + the_input
+        else
+          the_label + template.content_tag(SimpleForm.input_wrapper_tag, the_input , :class => SimpleForm.input_wrapper_class)
+        end
       end
     end
   end

--- a/test/form_builder_test.rb
+++ b/test/form_builder_test.rb
@@ -376,10 +376,24 @@ class FormBuilderTest < ActionView::TestCase
       assert_select 'form p input#user_name.string'
     end
   end
-  
+
+  test 'builder support input element wrapping around specified tag' do
+    swap SimpleForm, :input_wrapper_tag => :p do
+      with_form_for @user, :name
+      assert_select 'form div.input p input'
+    end
+  end
+
+  test 'builder input wrapping tag allows custom css class to be set' do
+    swap SimpleForm, :input_wrapper_tag => :p, :input_wrapper_class => 'custom' do
+      with_form_for @user, :name
+      assert_select 'form div.input p.custom input'
+    end
+  end
+
   test 'builder support no wrapping when wrapper is false' do
-    with_form_for @user, :name, :wrapper => false	
-    assert_select 'form > label[for=user_name]'	
+    with_form_for @user, :name, :wrapper => false
+    assert_select 'form > label[for=user_name]'
     assert_select 'form > input#user_name.string'
   end
 
@@ -418,6 +432,7 @@ class FormBuilderTest < ActionView::TestCase
     with_form_for @user, :name
     assert_select 'form div.input.required.string.field_with_errors'
   end
+
 
   # ONLY THE INPUT TAG
   test "builder input_field should only render the input tag, nothing else" do


### PR DESCRIPTION
Perhaps you might want to keep the generator the same, but these are the changes we had to make to get basic compatibility with bootstrap.
