### PR TITLE
Fallback to default label when block is provided

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -273,7 +273,7 @@ module SimpleForm
     #    f.label :name, :id => "cool_label"
     #
     def label(attribute_name, *args)
-      return super if args.first.is_a?(String)
+      return super if args.first.is_a?(String) || block_given?
       options = args.extract_options!
       options[:label_html] = options.dup
       options[:label]      = options.delete(:label)

--- a/test/form_builder/label_test.rb
+++ b/test/form_builder/label_test.rb
@@ -2,9 +2,9 @@
 require 'test_helper'
 
 class LabelTest < ActionView::TestCase
-  def with_label_for(object, *args)
+  def with_label_for(object, *args, &block)
     with_concat_form_for(object) do |f|
-      f.label(*args)
+      f.label(*args, &block)
     end
   end
 
@@ -30,6 +30,14 @@ class LabelTest < ActionView::TestCase
 
   test 'builder should fallback to default label when string is given' do
     with_label_for @user, :name, 'Nome do usuário'
+    assert_select 'label', 'Nome do usuário'
+    assert_no_select 'label.string'
+  end
+
+  test 'builder should fallback to default label when block is given' do
+    with_label_for @user, :name do
+      'Nome do usuário'
+    end
     assert_select 'label', 'Nome do usuário'
     assert_no_select 'label.string'
   end


### PR DESCRIPTION
`ActionView::Helpers::FormBuilder#label` takes a block, but currently `SimpleForm::FormBuilder#label` ignores the block it is given. This patch now calls the superclass's label method when a block is provided therefore bypassing the simple form logic.
