### PR TITLE
Make the HTML generated for collection fields valid

### DIFF
--- a/lib/simple_form/components/labels.rb
+++ b/lib/simple_form/components/labels.rb
@@ -22,7 +22,11 @@ module SimpleForm
       end
 
       def label
-        @builder.label(label_target, label_text, label_html_options)
+        res = @builder.label(label_target, label_text, label_html_options)
+        if !label_html_options.key?(:for) && input_type =~ /^radio|check_boxes$/
+          res = res.sub(/\sfor="[^"]*"/, '').html_safe
+        end
+        res
       end
 
       def label_text

--- a/test/components/label_test.rb
+++ b/test/components/label_test.rb
@@ -247,6 +247,33 @@ class IsolatedLabelTest < ActionView::TestCase
     assert_select 'label[for=project_name]', /Name/
   end
 
+  test 'label should include for attribute for select collection' do
+    with_label_for @user, :sex, :select, :collection => [:male, :female]
+    assert_select 'label[for=user_sex]'
+  end
+
+  test 'label should not include for attribute for radio collection' do
+    with_label_for @user, :sex, :radio, :collection => [:male, :female]
+    assert_select 'label'
+    assert_no_select 'label[for=user_sex]'
+  end
+
+  test 'label should include for attribute for radio collection when overwritten' do
+    with_label_for @user, :sex, :radio, :collection => [:male, :female], :label_html => { :for => 'sex' }
+    assert_select 'label[for=sex]'
+  end
+
+  test 'label should not include for attribute for check box collection' do
+    with_label_for @user, :hobbies, :check_boxes, :collection => [:sports, :movies, :shopping]
+    assert_select 'label'
+    assert_no_select 'label[for=user_hobbies]'
+  end
+
+  test 'label should include for attribute for check box collection when overwritten' do
+    with_label_for @user, :hobbies, :check_boxes, :collection => [:sports, :movies, :shopping], :label_html => { :for => 'hobbies' }
+    assert_select 'label[for=hobbies]'
+  end
+
   test 'label should use i18n properly when object is not present' do
     store_translations(:en, :simple_form => { :labels => {
       :project => { :name => 'Nome' }


### PR DESCRIPTION
By removing the `for` attribute from radio and check box collection main labels using a regular expression. The attribute is not removed if overwritten using `:label_html` even if this is perhaps useless.

A quick and dirty solution! I don't know SimpleForm enough to be sure it is completely safe, but it works for my forms.
