### PR TITLE
Fix SimpleForm/ActiveModel compatibility

### DIFF
--- a/lib/simple_form/helpers/has_errors.rb
+++ b/lib/simple_form/helpers/has_errors.rb
@@ -4,7 +4,7 @@ module SimpleForm
       private
 
       def has_errors?
-        object && object.respond_to?(:errors) && object.errors.present?
+        object.respond_to?(:errors) && object.errors.present?
       end
     end
   end


### PR DESCRIPTION
When using SimpleForm with ActiveModel, the `HasErrors` helper is not
properly calling the `#errors` method within `HasErrors`.  Instead, it's being
intercepted via some undetermined method.

This is the fix but I have yet to create a reproducible test.

Also, checking for `object` first is redundant since, if `object` responds to
`#errors`, it's obviously not `nil`

This is a rebase of #351.
