### PR TITLE
simple_fields_for inherites wrapper option from the parent form

### DIFF
--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -103,6 +103,8 @@ module SimpleForm
       #   end
       def simple_fields_for(*args, &block)
         options = args.extract_options!
+        options[:wrapper] ||= self.options[:wrapper]
+
         if self.class < ActionView::Helpers::FormBuilder
           options[:builder] ||= self.class
         else

--- a/test/action_view_extensions/builder_test.rb
+++ b/test/action_view_extensions/builder_test.rb
@@ -434,4 +434,14 @@ class BuilderTest < ActionView::TestCase
       end
     end
   end
+
+  test 'fields inherites wrapper option from the parent form' do
+    swap_wrapper :another do
+      simple_form_for(:user, :wrapper => :another) do |f|
+        f.simple_fields_for(:company) do |company|
+          assert_equal :another, company.options[:wrapper]
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
closes #357
