### PR TITLE
use action prefix in form css class, closes #360

### DIFF
--- a/lib/simple_form/action_view_extensions/form_helper.rb
+++ b/lib/simple_form/action_view_extensions/form_helper.rb
@@ -48,7 +48,8 @@ module SimpleForm
           record
         else
           record = record.last if record.is_a?(Array)
-          dom_class(record)
+          action = record.respond_to?(:persisted?) && record.persisted? ? :edit : :new
+          dom_class(record, action)
         end
       end
 

--- a/test/action_view_extensions/form_helper_test.rb
+++ b/test/action_view_extensions/form_helper_test.rb
@@ -42,9 +42,15 @@ class FormHelperTest < ActionView::TestCase
     assert_select 'form.simple_form.user'
   end
 
-  test 'simple form should add object class name as css class to form' do
+  test 'simple form should add object class name with new prefix as css class to form if record is not persisted' do
+    @user.new_record!
     concat(simple_form_for(@user) do |f| end)
-    assert_select 'form.simple_form.user'
+    assert_select 'form.simple_form.new_user'
+  end
+
+  test 'simple form should add edit class prefix as css class to form if record is persisted' do
+    concat(simple_form_for(@user) do |f| end)
+    assert_select 'form.simple_form.edit_user'
   end
 
   test 'simple form should not add object class to form if css_class is specified' do


### PR DESCRIPTION
closes #360.

And there is one thing: in Rails, `form_for :user` doesn't generate any form class. But SimpleForm generate. Should I fix it too? /cc @josevalim
