### PR TITLE
Add label_class option for collection_check_boxes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
     For more informations see [this comment](https://github.com/plataformatec/simple_form/issues/360#issuecomment-3000780).
     ([@nashby](https://github.com/nashby))
   * Add a readonly component that does automatically readonly lookup from object
-  * Add `label_class` option for collection_check_boxes. ([@jroes](https://github.com/jroes))
+  * Add `label_class` option for collection_check_boxes and collection_radio. ([@jroes](https://github.com/jroes))
 
 ### deprecation
   * Deprecate the `translate` configuration in favor of `translate_labels`

--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -36,13 +36,14 @@ module SimpleForm
       #   * collection_wrapper_class => the CSS class to use for collection_wrapper_tag
       #
       #   * item_wrapper_tag         => the tag to wrap each item in the collection.
+      #   * label_class              => the class to use for each radio button label.
       #
       def collection_radio(attribute, collection, value_method, text_method, options={}, html_options={})
         render_collection(
           attribute, collection, value_method, text_method, options, html_options
         ) do |value, text, default_html_options|
           radio_button(attribute, value, default_html_options) +
-            label(sanitize_attribute_name(attribute, value), text, :class => "collection_radio")
+            label(sanitize_attribute_name(attribute, value), text, :class => options[:label_class] || "collection_radio")
         end
       end
 

--- a/test/action_view_extensions/builder_test.rb
+++ b/test/action_view_extensions/builder_test.rb
@@ -198,6 +198,12 @@ class BuilderTest < ActionView::TestCase
     assert_no_select 'form label input'
   end
 
+ test 'collection radio uses label class for radio button labels' do
+    with_collection_radio @user, :active, [true, false], :to_s, :to_s, :label_class => 'my_radio_class'
+
+    assert_select 'form label[class=my_radio_class]'
+  end
+
   # COLLECTION CHECK BOX
   test 'collection check box accepts a collection and generate a serie of checkboxes for value method' do
     collection = [Tag.new(1, 'Tag 1'), Tag.new(2, 'Tag 2')]


### PR DESCRIPTION
This allows a user to specify the class for checkbox labels when using collection_check_boxes.
