### PR TITLE
move default attribute translations out of root

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,25 +490,30 @@ SimpleForm also lets you be more specific, separating lookups through actions fo
             password: 'Change password'
 ```
 
-This way SimpleForm will figure out the right translation for you, based on the action being rendered. And to be a little bit DRYer with your locale file, you can skip the model information inside it:
+This way SimpleForm will figure out the right translation for you, based on the action being rendered. And to be a little bit DRYer with your locale file, you can specify defaults for all models under the 'defaults' key:
 
 ```yaml
   en:
     simple_form:
       labels:
-        username: 'User name'
-        password: 'Password'
+        defaults:
+          username: 'User name'
+          password: 'Password'
+          new:
+            username: 'Choose a user name'
       hints:
-        username: 'User name to sign in.'
-        password: 'No special characters, please.'
+        defaults:
+          username: 'User name to sign in.'
+          password: 'No special characters, please.'
       placeholders:
-        username: 'Your username'
-        password: '****'
+        defaults:
+          username: 'Your username'
+          password: '****'
 ```
 
-SimpleForm will always look for a default attribute translation if no specific is found inside the model key. In addition, SimpleForm will fallback to default human_attribute_name from Rails when no other translation is found for labels.
+SimpleForm will always look for a default attribute translation under the "defaults" key if no specific is found inside the model key.Note that this syntax is different from 1.x. To migrate to the new syntax, just move "labels.#{attribute}" to "labels.defaults.#{attribute}".
 
-Finally, you can also overwrite any label, hint or placeholder inside your view, just by passing the option manually. This way the I18n lookup will be skipped.
+In addition, SimpleForm will fallback to default human_attribute_name from Rails when no other translation is found for labels. Finally, you can also overwrite any label, hint or placeholder inside your view, just by passing the option manually. This way the I18n lookup will be skipped.
 
 It's also possible to translate buttons, using Rails' built-in I18n support:
 

--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -105,7 +105,7 @@ module SimpleForm
       #
       #   simple_form.{namespace}.{model}.{action}.{attribute}
       #   simple_form.{namespace}.{model}.{attribute}
-      #   simple_form.{namespace}.{attribute}
+      #   simple_form.{namespace}.defaults.{attribute}
       #
       #  Namespace is used for :labels and :hints.
       #
@@ -144,7 +144,8 @@ module SimpleForm
           lookups << :"#{joined_model_names}.#{lookup_action}.#{reflection_or_attribute_name}"
           lookups << :"#{joined_model_names}.#{reflection_or_attribute_name}"
         end
-        lookups << :"defaults.#{attribute_name}" unless reflection
+        lookups << :"defaults.#{lookup_action}.#{reflection_or_attribute_name}"
+        lookups << :"defaults.#{attribute_name}"
         lookups << default
 
         I18n.t(lookups.shift, :scope => :"simple_form.#{namespace}", :default => lookups).presence

--- a/test/components/label_test.rb
+++ b/test/components/label_test.rb
@@ -73,6 +73,7 @@ class IsolatedLabelTest < ActionView::TestCase
   end
 
   test 'input should use i18n based only on attribute to lookup translation' do
+  test 'input should use i18n under defaults to lookup translation' do
     store_translations(:en, :simple_form => { :labels => { :defaults => {:age => 'Idade'} } } ) do
       with_label_for @user, :age, :integer
       assert_select 'label[for=user_age]', /Idade/

--- a/test/form_builder/hint_test.rb
+++ b/test/form_builder/hint_test.rb
@@ -79,19 +79,10 @@ class HintTest < ActionView::TestCase
     end
   end
 
-  test 'hint should not use i18n just with attribute to lookup translation if it is a model' do
-    store_translations(:en, :simple_form => { :hints => {
-      :company => { :name => 'Nome' }
-    } } ) do
-      with_hint_for @user, :company, :reflection => Association.new(Company, :company, {})
-      assert_no_select 'span.hint'
-    end
-  end
-
-  test 'hint should use i18n just with attribute to lookup translation' do
-    store_translations(:en, :simple_form => { :hints => {
-      :defaults => {:name => 'Content of this input will be downcased...'}
-    } }) do
+  test 'hint should use i18n under defaults namespace to lookup translation' do
+    store_translations(:en, :simple_form => {
+      :hints => {:defaults => {:name => 'Content of this input will be downcased...' } }
+    }) do
       with_hint_for @user, :name
       assert_select 'span.hint', 'Content of this input will be downcased...'
     end


### PR DESCRIPTION
(#384)
- move simpleform.label.username to simpleform.label.defaults.username
- update README
- allow lookup of reflections on simpleform.label.defaults

Conflicts:

```
lib/simple_form/inputs/base.rb
test/components/label_test.rb
test/form_builder/hint_test.rb
```
