### PR TITLE
don't get maxlength from validation when tokenizer present

### DIFF
--- a/lib/simple_form/components/maxlength.rb
+++ b/lib/simple_form/components/maxlength.rb
@@ -11,7 +11,7 @@ module SimpleForm
 
       def maximum_length_from_validation
         if options[:maxlength] == true
-          if length_validator = find_length_validator
+          if (length_validator = find_length_validator) && !length_validator.options[:tokenizer]
             length_validator.options[:maximum]
           end
         else

--- a/test/inputs/string_input_test.rb
+++ b/test/inputs/string_input_test.rb
@@ -47,6 +47,11 @@ class StringInputTest < ActionView::TestCase
     assert_select 'input.string[maxlength=25]'
   end
 
+  test 'input should not get maxlength from validation when tokenizer present' do
+    with_input_for @validating_user, :action, :string
+    assert_no_select 'input.string[maxlength]'
+  end
+
   test 'input should not generate placeholder by default' do
     with_input_for @user, :name, :string
     assert_no_select 'input[placeholder]'

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -155,6 +155,7 @@ class ValidatingUser < User
     :only_integer => true
   validates_length_of :name, :maximum => 25
   validates_length_of :description, :maximum => 50
+  validates_length_of :action, :maximum => 10, :tokenizer => lambda { |str| str.scan(/\w+/) }
 
   def min_amount
     10


### PR DESCRIPTION
because I think it's impossible to calculate the real length of input. 
