### PR TITLE
Clarify use of label_method versus text_method with collections 

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Collections can be arrays or ranges, and when a :collection is given the :select
 
 Collection inputs accepts two other options beside collections:
 
-* label_method => the label method to be applied to the collection to retrieve the label
+* label_method => the label method to be applied to the collection to retrieve the label (use this instead of the text_method option in collection_select)
 
 * value_method => the value method to be applied to the collection to retrieve the value
 


### PR DESCRIPTION
Added note regarding use of label_method instead of underlying text_method. The underlying collection_selection method for associations supports the text_method option for specifying the value to display in the select box; however, this does not work in simple_form, even though the documentation says that all other options are passed to the underlying method. In this case, you must use label_method.
