### PR TITLE
Mongoid compatibility improvement in belongs_to case 

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -173,7 +173,7 @@ module SimpleForm
 
       attribute = case reflection.macro
         when :belongs_to
-          reflection.options[:foreign_key] || :"#{reflection.name}_id"
+          (reflection.respond_to?(:options) && reflection.options[:foreign_key]) || :"#{reflection.name}_id"
         when :has_one
           raise ":has_one associations are not supported by f.association"
         else


### PR DESCRIPTION
(no more: undefined method `options' for  #Mongoid::Relations::Metadata)

In belongs_to case only :collection => Products.all is not help. :collection option is also necessary now, but not enough. This modification is help. I tried it with Mongoid 2.4.3 and mongoid 3.0.0 (master branch). This little modification made more compatible simple_form with mongoid and may be with others.
