### PR TITLE
Add extra "checkbox" class to label with nested style enabled using :label_input in wrapper config.

### DIFF
--- a/lib/simple_form/inputs/boolean_input.rb
+++ b/lib/simple_form/inputs/boolean_input.rb
@@ -16,8 +16,11 @@ module SimpleForm
         if options[:label] == false
           input
         elsif nested_boolean_style?
+          html_options = label_html_options.dup
+          html_options[:class].push(:checkbox)
+
           build_hidden_field_for_checkbox +
-            @builder.label(label_target, label_html_options) {
+            @builder.label(label_target, html_options) {
               build_check_box_without_hidden_field + label_text
             }
         else

--- a/test/inputs/boolean_input_test.rb
+++ b/test/inputs/boolean_input_test.rb
@@ -88,4 +88,14 @@ class BooleanInputTest < ActionView::TestCase
       end
     end
   end
+
+  test 'input boolean with nested style works using :label_input in wrapper config, adding "checkbox" class to label' do
+    swap_wrapper :default, self.custom_wrapper_without_top_level do
+      swap SimpleForm, :boolean_style => :nested do
+        with_input_for @user, :active, :boolean
+
+        assert_select 'input[type=hidden] + label.boolean.checkbox > input.boolean'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Should close #426 with wrapper

``` ruby
config.wrappers :checkbox, :tag => 'div', :class => 'control-group', :error_class => 'error' do |b|
  b.use :tag => 'div', :class => 'controls' do |ba|
    ba.use :label_input
  end
end
```

``` slim
= form.input :remember_me,      \
              as: :boolean,  \
              label: 'Remember my login on this computer', \
              wrapper: :checkbox
```
