### PR TITLE
Fix label for datetime inputs, point to first select

### DIFF
--- a/lib/simple_form/inputs/date_time_input.rb
+++ b/lib/simple_form/inputs/date_time_input.rb
@@ -14,7 +14,10 @@ module SimpleForm
       def label_target
         case input_type
         when :date, :datetime
-          "#{attribute_name}_1i"
+          date_order = input_options[:order] || I18n.t('date.order')
+          type = date_order.first
+          position = ActionView::Helpers::DateTimeSelector::POSITION[type]
+          "#{attribute_name}_#{position}i"
         when :time
           "#{attribute_name}_4i"
         end

--- a/test/inputs/datetime_input_test.rb
+++ b/test/inputs/datetime_input_test.rb
@@ -62,14 +62,28 @@ class DateTimeInputTest < ActionView::TestCase
     assert_select 'select.time option', 'minuto'
   end
 
-  test 'label should point to first option when date input type' do
-    with_input_for :project, :created_at, :date
-    assert_select 'label[for=project_created_at_1i]'
+  test 'label should use i18n to get target for date input type' do
+    store_translations(:en, :date => { :order => [:month, :day, :year] }) do
+      with_input_for :project, :created_at, :date
+      assert_select 'label[for=project_created_at_2i]'
+    end
   end
 
-  test 'label should point to first option when datetime input type' do
-    with_input_for :project, :created_at, :datetime
-    assert_select 'label[for=project_created_at_1i]'
+  test 'label should use i18n to get target for datetime input type' do
+    store_translations(:en, :date => { :order => [:month, :day, :year] }) do
+      with_input_for :project, :created_at, :datetime
+      assert_select 'label[for=project_created_at_2i]'
+    end
+  end
+
+  test 'label should use order to get target when date input type' do
+    with_input_for :project, :created_at, :date, :order => [:month, :year, :day]
+    assert_select 'label[for=project_created_at_2i]'
+  end
+
+  test 'label should use order to get target when datetime input type' do
+    with_input_for :project, :created_at, :datetime, :order => [:month, :year, :day]
+    assert_select 'label[for=project_created_at_2i]'
   end
 
   test 'label should point to first option when time input type' do

--- a/test/support/misc_helpers.rb
+++ b/test/support/misc_helpers.rb
@@ -5,6 +5,7 @@ module MiscHelpers
       yield
     ensure
       I18n.reload!
+      I18n.backend.send :init_translations
     end
   end
 


### PR DESCRIPTION
Point the label for datetime inputs at the first select. The date order can be
overridden by i18n and on a per-input basis. Use the specified order to
discover the first select.
