### PR TITLE
fixes issue with generated help-block (hint) when used within the prepend/append wrapper for twitter bootstrap

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb.tt
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb.tt
@@ -58,11 +58,11 @@ SimpleForm.setup do |config|
   config.wrappers :prepend, :tag => 'div', :class => "control-group", :error_class => 'error' do |b|
     b.use :placeholder
     b.use :label, :class => 'control-label'
-    b.use :hint,  :tag => 'span', :class => 'help-block'
     b.use :tag => 'div', :class => 'controls' do |input|
       input.use :tag => 'div', :class => 'input-prepend' do |prepend|
         prepend.use :input
       end
+      input.use :hint,  :tag => 'span', :class => 'help-block'
       input.use :error, :tag => 'span', :class => 'help-inline'
     end
   end
@@ -70,11 +70,11 @@ SimpleForm.setup do |config|
   config.wrappers :append, :tag => 'div', :class => "control-group", :error_class => 'error' do |b|
     b.use :placeholder
     b.use :label, :class => 'control-label'
-    b.use :hint,  :tag => 'span', :class => 'help-block'
     b.use :tag => 'div', :class => 'controls' do |input|
       input.use :tag => 'div', :class => 'input-append' do |append|
         append.use :input
       end
+      input.use :hint,  :tag => 'span', :class => 'help-block'
       input.use :error, :tag => 'span', :class => 'help-inline'
     end
   end


### PR DESCRIPTION
When using wrappers for twitter bootstrap, the html code that gets generated by the "append" and "prepend" wrappers for twitter bootstrap locate the hint (help-block) in the wrong location.

The generated code is:

``` html
<div class="control-group string required">
  <label class="string required" for="account_subdomain"><abbr title="required">*</abbr> Subdomain</label>
  <span class="help-block">This is some help text! foo! foo!.</span>
  <div class="controls">
    <div class="input-append">
      <input class="string required disabled" disabled="disabled" id="account_subdomain" name="account[subdomain]" size="50" type="text" value="rogelio">
      <span class="add-on">minutolog.com</span>
    </div>
  </div>
</div>
```

And it should be:

``` html
<div class="control-group string required">
  <label class="string required" for="account_subdomain"><abbr title="required">*</abbr> Subdomain</label>
  <span class="help-block">This is some help text! foo! foo!.</span>
  <div class="controls">
    <div class="input-append">
      <input class="string required disabled" disabled="disabled" id="account_subdomain" name="account[subdomain]" size="50" type="text" value="rogelio">
      <span class="add-on">minutolog.com</span>
    </div>
    <span class="help-block">This is some help text! foo! foo!.</span>
  </div>
</div>
```
