### PR TITLE
Consistently refer to SimpleForm in docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://secure.travis-ci.org/plataformatec/simple_form.png)](http://travis-ci.org/plataformatec/simple_form)
 
 **SimpleForm** aims to be as flexible as possible while helping you with powerful components to create
-your forms. The basic goal of simple form is to not touch your way of defining the layout, letting
+your forms. The basic goal of SimpleForm is to not touch your way of defining the layout, letting
 you find the better design for your eyes. Most of the DSL was inherited from Formtastic,
 which we are thankful for and should make you feel right at home.
 
@@ -485,7 +485,7 @@ on `simple_form_for` helper. They are listed below.
 
 ### Simple Fields For
 
-Wrapper to use simple form inside a default rails form
+Wrapper to use SimpleForm inside a default rails form
 
 ```ruby
 form_for @user do |f|

--- a/lib/generators/simple_form/install_generator.rb
+++ b/lib/generators/simple_form/install_generator.rb
@@ -8,7 +8,7 @@ module SimpleForm
 
       def info_bootstrap
         return if options.bootstrap?
-        puts "Simple Form 2 supports Twitter bootstrap. In case you want to " \
+        puts "SimpleForm 2 supports Twitter bootstrap. In case you want to " \
           "generate bootstrap configuration, please re-run this " \
           "generator passing --bootstrap as option."
       end

--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb.tt
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb.tt
@@ -171,6 +171,6 @@ SimpleForm.setup do |config|
   # Automatically discover new inputs in Rails' autoload path.
   # config.inputs_discovery = true
 
-  # Cache simple form inputs discovery
+  # Cache SimpleForm inputs discovery
   # config.cache_discovery = !Rails.env.development?
 end

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -116,7 +116,7 @@ module SimpleForm
   mattr_accessor :inputs_discovery
   @@inputs_discovery = true
 
-  # Cache simple form inputs discovery
+  # Cache SimpleForm inputs discovery
   mattr_accessor :cache_discovery
   @@cache_discovery = defined?(Rails) && !Rails.env.development?
 
@@ -207,7 +207,7 @@ module SimpleForm
     yield self
 
     unless @@deprecated.empty?
-      raise "[SIMPLE FORM] Your simple form initializer file is using the following methods: #{@@deprecated.to_sentence}. " <<
+      raise "[SIMPLE FORM] Your SimpleForm initializer file is using the following methods: #{@@deprecated.to_sentence}. " <<
         "Those methods are part of the outdated configuration API. Updating to the new API is easy and fast. " <<
         "Check for more info here: https://github.com/plataformatec/simple_form/wiki/Upgrading-to-Simple-Form-2.0"
     end

--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -183,7 +183,7 @@ module SimpleForm
         wrap_rendered_collection(rendered_collection + hidden, options)
       end
 
-      # Wrapper for using simple form inside a default rails form.
+      # Wrapper for using SimpleForm inside a default rails form.
       # Example:
       #
       #   form_for @user do |f|

--- a/lib/simple_form/action_view_extensions/form_helper.rb
+++ b/lib/simple_form/action_view_extensions/form_helper.rb
@@ -1,6 +1,6 @@
 module SimpleForm
   module ActionViewExtensions
-    # This module creates simple form wrappers around default form_for and fields_for.
+    # This module creates SimpleForm wrappers around default form_for and fields_for.
     #
     # Example:
     #

--- a/test/action_view_extensions/form_helper_test.rb
+++ b/test/action_view_extensions/form_helper_test.rb
@@ -2,23 +2,23 @@ require 'test_helper'
 
 class FormHelperTest < ActionView::TestCase
 
-  test 'simple form for yields an instance of FormBuilder' do
+  test 'SimpleForm for yields an instance of FormBuilder' do
     simple_form_for :user do |f|
       assert f.instance_of?(SimpleForm::FormBuilder)
     end
   end
 
-  test 'simple form should add default class to form' do
+  test 'SimpleForm should add default class to form' do
     concat(simple_form_for(:user) do |f| end)
     assert_select 'form.simple_form'
   end
 
-  test 'simple form should use default browser validations by default' do
+  test 'SimpleForm should use default browser validations by default' do
     concat(simple_form_for(:user) do |f| end)
     assert_no_select 'form[novalidate]'
   end
 
-  test 'simple form should not use default browser validations if specified in the configuration options' do
+  test 'SimpleForm should not use default browser validations if specified in the configuration options' do
     swap SimpleForm, :browser_validations => false do
       concat(simple_form_for(:user) do |f| end)
       assert_select 'form[novalidate="novalidate"]'
@@ -37,49 +37,49 @@ class FormHelperTest < ActionView::TestCase
     end
   end
 
-  test 'simple form should add object name as css class to form when object is not present' do
+  test 'SimpleForm should add object name as css class to form when object is not present' do
     concat(simple_form_for(:user) do |f| end)
     assert_select 'form.simple_form.user'
   end
 
-  test 'simple form should add :as option as css class to form when object is not present' do
+  test 'SimpleForm should add :as option as css class to form when object is not present' do
     concat(simple_form_for(:user, :as => 'superuser') do |f| end)
     assert_select 'form.simple_form.superuser'
   end
 
-  test 'simple form should add object class name with new prefix as css class to form if record is not persisted' do
+  test 'SimpleForm should add object class name with new prefix as css class to form if record is not persisted' do
     @user.new_record!
     concat(simple_form_for(@user) do |f| end)
     assert_select 'form.simple_form.new_user'
   end
 
-  test 'simple form should add :as option with new prefix as css class to form if record is not persisted' do
+  test 'SimpleForm should add :as option with new prefix as css class to form if record is not persisted' do
     @user.new_record!
     concat(simple_form_for(@user, :as => 'superuser') do |f| end)
     assert_select 'form.simple_form.new_superuser'
   end
 
-  test 'simple form should add edit class prefix as css class to form if record is persisted' do
+  test 'SimpleForm should add edit class prefix as css class to form if record is persisted' do
     concat(simple_form_for(@user) do |f| end)
     assert_select 'form.simple_form.edit_user'
   end
 
-  test 'simple form should add :as options with edit prefix as css class to form if record is persisted' do
+  test 'SimpleForm should add :as options with edit prefix as css class to form if record is persisted' do
     concat(simple_form_for(@user, :as => 'superuser') do |f| end)
     assert_select 'form.simple_form.edit_superuser'
   end
 
-  test 'simple form should not add object class to form if css_class is specified' do
+  test 'SimpleForm should not add object class to form if css_class is specified' do
     concat(simple_form_for(:user, :html => {:class => nil}) do |f| end)
     assert_no_select 'form.user'
   end
 
-  test 'simple form should add custom class to form if css_class is specified' do
+  test 'SimpleForm should add custom class to form if css_class is specified' do
     concat(simple_form_for(:user, :html => {:class => 'my_class'}) do |f| end)
     assert_select 'form.my_class'
   end
 
-  test 'pass options to simple form' do
+  test 'pass options to SimpleForm' do
     concat(simple_form_for(:user, :url => '/account', :html => { :id => 'my_form' }) do |f| end)
     assert_select 'form#my_form'
     assert_select 'form[action=/account]'

--- a/test/inputs/priority_input_test.rb
+++ b/test/inputs/priority_input_test.rb
@@ -9,7 +9,7 @@ class PriorityInputTest < ActionView::TestCase
     assert_no_select 'select option[value=][disabled=disabled]'
   end
 
-  test 'input should generate a country select with simple form default' do
+  test 'input should generate a country select with SimpleForm default' do
     swap SimpleForm, :country_priority => [ 'Brazil' ] do
       with_input_for @user, :country, :country
       assert_select 'select option[value=][disabled=disabled]'

--- a/test/inputs/string_input_test.rb
+++ b/test/inputs/string_input_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class StringInputTest < ActionView::TestCase
   test 'input should map text field to string attribute' do
     with_input_for @user, :name, :string
-    assert_select "input#user_name[type=text][name='user[name]'][value=New in Simple Form!]"
+    assert_select "input#user_name[type=text][name='user[name]'][value=New in SimpleForm!]"
   end
 
   test 'input should generate a password field for password attributes' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,14 +51,14 @@ class ActionView::TestCase
   def setup_new_user(options={})
     @user = User.new({
       :id => 1,
-      :name => 'New in Simple Form!',
+      :name => 'New in SimpleForm!',
       :description => 'Hello!',
       :created_at => Time.now
     }.merge(options))
 
     @validating_user = ValidatingUser.new({
       :id => 1,
-      :name => 'New in Simple Form!',
+      :name => 'New in SimpleForm!',
       :description => 'Hello!',
       :home_picture => 'Home picture',
       :created_at => Time.now,
@@ -70,7 +70,7 @@ class ActionView::TestCase
 
     @other_validating_user = OtherValidatingUser.new({
       :id => 1,
-      :name => 'New in Simple Form!',
+      :name => 'New in SimpleForm!',
       :description => 'Hello!',
       :created_at => Time.now,
       :age => 19,


### PR DESCRIPTION
I'm currently writing a blog post on SimpleForm 2.0 and was trying to find out if I should refer to it as "SimpleForm", "Simple Form", "simple_form", or something else entirely. The gem name is quite obviously simple_form, but most official looking places (README and Documenation) refer to "SimpleForm". There are instances of "Simple Form" sprinkled throughout both as well.

It might seem silly, but I wanted to be sure I was getting the name right. It seems the gem should be referred to as "SimpleForm" in text and "simple_form" in code, so I stuck with that and removed all instances of "simple form" except in deprecation messages where "SIMPLEFORM" looks silly.

All tests pass.
