### PR TITLE
fixing documentation to reflect code behavior

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb.tt
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb.tt
@@ -145,7 +145,7 @@ SimpleForm.setup do |config|
   # config.required_by_default = true
 
   # Tell browsers whether to use default HTML5 validations (novalidate option).
-  # Default is enabled.
+  # Default is disabled.
   config.browser_validations = false
 
   # Collection of methods to detect if a file type was given.


### PR DESCRIPTION
The documentation has not been updated when the configuration has been changed.
It should also say "disabled".
