### PR TITLE
Don't leak out minimum or maximum values when MinMax component is in use

### DIFF
--- a/lib/simple_form/components/min_max.rb
+++ b/lib/simple_form/components/min_max.rb
@@ -7,6 +7,7 @@ module SimpleForm
           input_html_options[:min] ||= minimum_value(validator_options)
           input_html_options[:max] ||= maximum_value(validator_options)
         end
+        nil
       end
 
       private

--- a/test/inputs/numeric_input_test.rb
+++ b/test/inputs/numeric_input_test.rb
@@ -164,4 +164,10 @@ class NumericInputTest < ActionView::TestCase
       assert_select 'input[max=99]'
     end
   end
+
+  test 'min_max should not emit max value as bare string' do
+    with_input_for @other_validating_user, :age, :integer
+    assert_select 'div', {:count => 0, :text => %r{^99}}
+  end
+
 end


### PR DESCRIPTION
In 2.0.1 either min or max numbers leak out just before label. Fixes #483.
