### PR TITLE
simple_form.en.yml should use english only

### DIFF
--- a/lib/generators/simple_form/templates/config/locales/simple_form.en.yml
+++ b/lib/generators/simple_form/templates/config/locales/simple_form.en.yml
@@ -15,7 +15,7 @@ en:
     #   password: 'Password'
     #   user:
     #     new:
-    #       email: 'E-mail para efetuar o sign in.'
+    #       email: 'E-mail to sign in.'
     #     edit:
     #       email: 'E-mail.'
     # hints:


### PR DESCRIPTION
The i18n sample file should use english only example phrases.
