### PR TITLE
Fix checked radio button issue when value is false

### DIFF
--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -216,7 +216,8 @@ module SimpleForm
         html_options = html_options.dup
 
         [:checked, :selected, :disabled].each do |option|
-          next unless current_option = options[option]
+          current_option = options[option]
+          next if current_option.nil?
 
           accept = if current_option.respond_to?(:call)
             current_option.call(item)

--- a/test/action_view_extensions/builder_test.rb
+++ b/test/action_view_extensions/builder_test.rb
@@ -63,6 +63,12 @@ class BuilderTest < ActionView::TestCase
     assert_select 'form input[type=radio][value=true][checked=checked]'
     assert_no_select 'form input[type=radio][value=false][checked=checked]'
   end
+ 
+  test 'collection radio accepts checked item which has a value of false' do
+    with_collection_radio_buttons @user, :active, [[1, true], [0, false]], :last, :first, :checked => false
+    assert_no_select 'form input[type=radio][value=true][checked=checked]'
+    assert_select 'form input[type=radio][value=false][checked=checked]'
+  end
 
   test 'collection radio accepts multiple disabled items' do
     collection = [[1, true], [0, false], [2, 'other']]


### PR DESCRIPTION
Setting the `:checked` value to `false` for a radio button collection didn't render the correct HTML. The radio button with the value of `false` didn't get the `checked` attribute. This commit fixes the issue.
