### PR TITLE
Make a copy of input options before modification so options passed by reference are not altered

### DIFF
--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -48,6 +48,7 @@ module SimpleForm
       def initialize(builder, attribute_name, column, input_type, options = {})
         super
 
+        options             = options.dup
         @builder            = builder
         @attribute_name     = attribute_name
         @column             = column


### PR DESCRIPTION
I'm having trouble using simple_form if the options used in the markup are passed by reference:

e.g

```
f.input :name, some_configuration_variable
```

Keys like :collection are deleted from the configuration hash when the input is being built. When the page reloads I'm missing those keys modified inside the Input classe(s).

Dup'ing the options in Inputs::Base seems to make simple_form play nice.
