### PR TITLE
Enhance description of config.error_method.

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb.tt
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb.tt
@@ -100,7 +100,9 @@ SimpleForm.setup do |config|
   # Default class for buttons
   config.button_class = 'btn'
 
-  # Method used to tidy up errors.
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # Use :to_sentence to list all errors for each field.
   # config.error_method = :first
 
   # Default tag used for error notification helper.


### PR DESCRIPTION
Clarify that error_method uses Rails Array methods, suggest two common usages.
