### PR TITLE
add .rvmrc to gitignore incase dev is using rvm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.rvmrc
 .bundle/
 pkg/
 rdoc/


### PR DESCRIPTION
A convenience.  Feel free not to merge if you don't agree.
