### PR TITLE
Copy edited error_notification.default_message.

### DIFF
--- a/lib/generators/simple_form/templates/config/locales/simple_form.en.yml
+++ b/lib/generators/simple_form/templates/config/locales/simple_form.en.yml
@@ -9,7 +9,7 @@ en:
       # When using html, text and mark won't be used.
       # html: '<abbr title="required">*</abbr>'
     error_notification:
-      default_message: "Please fix the problems below:"
+      default_message: "Please review the problems below:"
     # Labels and hints examples
     # labels:
     #   defaults:


### PR DESCRIPTION
The previous phrasing — "Some errors were found, please take a look:" — is bad English for several reasons:

• It's grammatically incorrect. "Some errors were found" and "please take a look" are independent clauses, so they can't be joined by a comma. You must either use a semicolon ("Some errors were found; please take a look:") or turn them into two separate sentences ("Some errors were found. Please take a look:").

• The passive voice of "errors were found" seems evasive and wishy-washy. Error found where? By whom? It's unpleasantly reminiscent of "mistakes were made."

I've proposed an entirely different wording which is both stronger and more concise. If you don't like it, you should at least fix the punctuation error (making it "Some errors were found. Please take a look:").

P.S. Thanks for the excellent project.
