### PR TITLE
Preserve ActionView::Base.field_error_proc

### DIFF
--- a/lib/simple_form/action_view_extensions/form_helper.rb
+++ b/lib/simple_form/action_view_extensions/form_helper.rb
@@ -43,10 +43,12 @@ module SimpleForm
 
       def with_simple_form_field_error_proc
         default_field_error_proc = ::ActionView::Base.field_error_proc
-        ::ActionView::Base.field_error_proc = FIELD_ERROR_PROC
-        result = yield
-        ::ActionView::Base.field_error_proc = default_field_error_proc
-        result
+        begin
+          ::ActionView::Base.field_error_proc = FIELD_ERROR_PROC
+          yield
+        ensure
+          ::ActionView::Base.field_error_proc = default_field_error_proc
+        end
       end
 
       def simple_form_css_class(record, options)

--- a/test/action_view_extensions/form_helper_test.rb
+++ b/test/action_view_extensions/form_helper_test.rb
@@ -109,9 +109,35 @@ class FormHelperTest < ActionView::TestCase
       expected_error_proc = lambda {}
       ActionView::Base.field_error_proc = expected_error_proc
 
+      result = nil
       simple_form_for :user do |f|
-        simple_fields_for 'address' do
+        result = simple_fields_for 'address' do
+          'hello'
         end
+      end
+
+      assert_equal 'hello', result
+      assert_equal expected_error_proc, ActionView::Base.field_error_proc
+
+    ensure
+      ActionView::Base.field_error_proc = previous_error_proc
+    end
+  end
+
+  test 'custom error proc survives an exception' do
+    previous_error_proc = ActionView::Base.field_error_proc
+
+    begin
+      expected_error_proc = lambda {}
+      ActionView::Base.field_error_proc = expected_error_proc
+
+      begin
+        simple_form_for :user do |f|
+          simple_fields_for 'address' do
+            raise 'an exception'
+          end
+        end
+      rescue StandardError => e
       end
 
       assert_equal expected_error_proc, ActionView::Base.field_error_proc


### PR DESCRIPTION
I'm migrating an app to use simple_form, and I've run into a few situations where nested calls to some of the simple_form methods results in `ActionView::Base.field_error_proc` getting trampled. This manifested itself in an app by preventing its custom error proc from getting called on any non-simple_form page after a page with the nested simple_form calls was loaded.

I solved this issue by using a local variable to hold the value of the existing proc instead of a class variable.

It is possible to avoid this without making changes to simple_form (for example, by using `form.fields_for` instead of `simple_fields_for` inside of a `simple_form_for` block), but it doesn't seem like it should be possible to corrupt an application's configuration by calling any of the supported API methods.

I also attempted to make sure the original error proc was restored even when an exception was raised inside `with_simple_form_field_error_proc`.
