### PR TITLE
Place hidden field after checkbox

### DIFF
--- a/lib/simple_form/inputs/boolean_input.rb
+++ b/lib/simple_form/inputs/boolean_input.rb
@@ -3,10 +3,9 @@ module SimpleForm
     class BooleanInput < Base
       def input
         if nested_boolean_style?
-          build_hidden_field_for_checkbox +
-            template.label_tag(nil, :class => "checkbox") {
-              build_check_box_without_hidden_field + inline_label
-            }
+          template.label_tag(nil, :class => "checkbox") {
+            build_check_box_without_hidden_field + inline_label
+          } + build_hidden_field_for_checkbox
         else
           build_check_box
         end
@@ -19,10 +18,9 @@ module SimpleForm
           html_options = label_html_options.dup
           html_options[:class].push(:checkbox)
 
-          build_hidden_field_for_checkbox +
-            @builder.label(label_target, html_options) {
-              build_check_box_without_hidden_field + label_text
-            }
+          @builder.label(label_target, html_options) {
+            build_check_box_without_hidden_field + label_text
+          } + build_hidden_field_for_checkbox
         else
           input + label
         end

--- a/test/inputs/boolean_input_test.rb
+++ b/test/inputs/boolean_input_test.rb
@@ -47,7 +47,7 @@ class BooleanInputTest < ActionView::TestCase
     swap SimpleForm, :boolean_style => :nested do
       with_input_for @user, :active, :boolean
 
-      assert_select "input[type=hidden][name='user[active]'] + label.boolean > input.boolean"
+      assert_select "label.boolean + input[type=hidden][name='user[active]']"
       assert_no_select 'input[type=checkbox] + label'
     end
   end
@@ -56,7 +56,7 @@ class BooleanInputTest < ActionView::TestCase
     swap SimpleForm, :boolean_style => :nested do
       with_input_for @user, :active, :boolean, :disabled => true
 
-      assert_select "input[type=hidden][name='user[active]'][disabled] + label.boolean > input.boolean[disabled]"
+      assert_select "label.boolean + input[type=hidden][name='user[active]'][disabled]"
     end
   end
 
@@ -98,7 +98,7 @@ class BooleanInputTest < ActionView::TestCase
       swap SimpleForm, :boolean_style => :nested do
         with_input_for @user, :active, :boolean
 
-        assert_select 'label.boolean + input[type=hidden] + label.checkbox > input.boolean'
+        assert_select 'label.boolean + label.checkbox > input.boolean'
       end
     end
   end
@@ -108,7 +108,7 @@ class BooleanInputTest < ActionView::TestCase
       swap SimpleForm, :boolean_style => :nested do
         with_input_for @user, :active, :boolean
 
-        assert_select 'input[type=hidden] + label.boolean.checkbox > input.boolean'
+        assert_select 'label.boolean.checkbox > input.boolean'
       end
     end
   end


### PR DESCRIPTION
Bootstrap has a selector that targets .checkbox:first-child, but placing
the hidden field before the checkbox label prevented this selector from
matching.
