### PR TITLE
Fix error when collection_check_boxes used with form_for instead of simple_form_for

### DIFF
--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -177,7 +177,7 @@ module SimpleForm
 
         # Append a hidden field to make sure something will be sent back to the
         # server if all checkboxes are unchecked.
-        hidden = template.hidden_field_tag("#{object_name}[#{attribute}][]", "", :id => nil)
+        hidden = @template.hidden_field_tag("#{object_name}[#{attribute}][]", "", :id => nil)
 
         wrap_rendered_collection(rendered_collection + hidden, options)
       end


### PR DESCRIPTION
When collection_check_boxes is used within a form_for block, it errors with:

undefined local variable or method `template' for #ActionView::Helpers::FormBuilder:0xab94560

I traced this to a call to template (not @template) in SimpleForm::ActionViewExtensions::Builder::collection_check_boxes . Changing the object to @template fixed the defect.
