### PR TITLE
readonly attributes comparison

### DIFF
--- a/lib/simple_form/components/readonly.rb
+++ b/lib/simple_form/components/readonly.rb
@@ -15,7 +15,7 @@ module SimpleForm
       def readonly_attribute?
         object.class.respond_to?(:readonly_attributes) &&
           object.persisted? &&
-          object.class.readonly_attributes.include?(attribute_name)
+          object.class.readonly_attributes.include?(attribute_name.to_s)
       end
     end
   end

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -130,7 +130,7 @@ class User
   end
 
   def self.readonly_attributes
-    [:credit_card]
+    ["credit_card"]
   end
 end
 


### PR DESCRIPTION
ActiveRecord.readonly_attributes returns a set of strings, not a set of
symbols. Verified with Rails 2.3 and 3.2.

``` ruby
class Foobar < ActiveRecord::Base
  attr_accessible :a
  attr_readonly :b
end

Foobar.readonly_attributes
=> #<Set: {"b"}>

irb(main):003:0> Foobar.readonly_attributes.include?(:b)
=> false
irb(main):004:0> Foobar.readonly_attributes.include?("b")
=> true
```
