### PR TITLE
add failing test for issue when input_html options apply to wrapper

### DIFF
--- a/test/form_builder/general_test.rb
+++ b/test/form_builder/general_test.rb
@@ -202,6 +202,14 @@ class FormBuilderTest < ActionView::TestCase
     assert_select 'form input#my_input.my_input.string'
   end
 
+  test 'builder should not propagate input options to wrapper with custom wrapper' do
+    swap_wrapper :default, self.custom_wrapper_with_wrapped_input do
+      with_form_for @user, :name, :input_html => { :class => 'my_input' }
+      assert_no_select 'form div.input.my_input'
+      assert_select 'form input.my_input.string'
+    end
+  end
+
   test 'builder should generate a input with label' do
     with_form_for @user, :name
     assert_select 'form label.string[for=user_name]', /Name/

--- a/test/support/misc_helpers.rb
+++ b/test/support/misc_helpers.rb
@@ -46,6 +46,15 @@ module MiscHelpers
     end
   end
 
+  def custom_wrapper_with_wrapped_input
+    SimpleForm.build :tag => :div, :class => "custom_wrapper" do |b|
+      b.wrapper :tag => :div, :class => 'elem' do |component|
+        component.use :label
+        component.use :input, :wrap_with => { :tag => :div, :class => 'input' }
+      end
+    end
+  end
+
   def custom_wrapper_without_top_level
     SimpleForm.build :tag => false, :class => 'custom_wrapper_without_top_level' do |b|
       b.use :label_input


### PR DESCRIPTION
Not sure how to fix it so I've decided to add a failing test for now. If somebody can point me to the right direction that would be great.
