### PR TITLE
prevent generation of class=""

### DIFF
--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -119,7 +119,7 @@ module SimpleForm
         html_options = options[:"#{namespace}_html"]
         html_options = html_options ? html_options.dup : {}
         css_classes << html_options[:class] if html_options.key?(:class)
-        html_options[:class] = css_classes
+        html_options[:class] = css_classes unless css_classes.empty?
         html_options
       end
 

--- a/lib/simple_form/wrappers/root.rb
+++ b/lib/simple_form/wrappers/root.rb
@@ -27,7 +27,7 @@ module SimpleForm
         css += SimpleForm.additional_classes_for(:wrapper) { input.html_classes }
         css << (options[:wrapper_error_class] || @defaults[:error_class]) if input.has_errors?
         css << (options[:wrapper_hint_class] || @defaults[:hint_class]) if input.has_hint?
-        css
+        css.compact
       end
     end
   end

--- a/test/components/label_test.rb
+++ b/test/components/label_test.rb
@@ -181,6 +181,13 @@ class IsolatedLabelTest < ActionView::TestCase
     end
   end
 
+  test 'label should not generate empty css class' do
+    swap SimpleForm, :generate_additional_classes_for => [:wrapper, :input] do
+      with_label_for @user, :name, :string
+      assert_no_select 'label[class]'
+    end
+  end
+
   test 'label should obtain required from ActiveModel::Validations when it is included' do
     with_label_for @validating_user, :name, :string
     assert_select 'label.required'

--- a/test/form_builder/wrapper_test.rb
+++ b/test/form_builder/wrapper_test.rb
@@ -75,6 +75,15 @@ class WrapperTest < ActionView::TestCase
     end
   end
 
+  test 'wrapper should not generate empty css class' do
+    swap SimpleForm, :generate_additional_classes_for => [:input, :label] do
+      swap_wrapper :default, custom_wrapper_without_class do
+        with_form_for @user, :name
+        assert_no_select 'div#custom_wrapper_without_class[class]'
+      end
+    end
+  end
+
   # Custom wrapper test
 
   test 'custom wrappers works' do

--- a/test/inputs/general_test.rb
+++ b/test/inputs/general_test.rb
@@ -66,4 +66,12 @@ class InputTest < ActionView::TestCase
     with_input_for :project, :name, :select, :collection => ['Jose', 'Carlos']
     assert_select 'select.select#project_name'
   end
+  
+  test 'input should not generate empty css class' do
+    swap SimpleForm, :generate_additional_classes_for => [:wrapper, :label] do
+      with_input_for :project, :name, :string
+      assert_no_select 'input#project_name[class]'
+    end
+  end
+  
 end

--- a/test/support/misc_helpers.rb
+++ b/test/support/misc_helpers.rb
@@ -72,6 +72,12 @@ module MiscHelpers
     end
   end
 
+  def custom_wrapper_without_class
+    SimpleForm.build :tag => :div, :wrapper_html => { :id => 'custom_wrapper_without_class' } do |b|
+      b.use :label_input
+    end
+  end
+
   def custom_wrapper_with_label_html_option
     SimpleForm.build :tag => :div, :class => "custom_wrapper", :label_html => { :class => 'extra-label-class' } do |b|
       b.use :label_input


### PR DESCRIPTION
I noticed that when generate_additional_classes_for is used, the html includes empty class="" markup like so,

``` html
<div class="form__row">
  <label class="" for="author_first_name">First name</label>
  <div class="form__row__body">
    <input name="author[first_name]" id="author_first_name" class="" type="text" />
  </div>
</div>
```

This change ensures that simple form does not generate empty class attributes.
