### PR TITLE
Explaining gotcha with the :collection_wrapper_class option.

### DIFF
--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -153,7 +153,8 @@ module SimpleForm
       #
       #   * collection_wrapper_tag   => the tag to wrap the entire collection.
       #
-      #   * collection_wrapper_class => the CSS class to use for collection_wrapper_tag
+      #   * collection_wrapper_class => the CSS class to use for collection_wrapper_tag. This option
+      #                                 is ignored if the :collection_wrapper_tag option is blank.
       #
       #   * item_wrapper_tag         => the tag to wrap each item in the collection.
       #


### PR DESCRIPTION
I was using

```
<%= f.collection_check_boxes :product_ids, Product.all, :id, :name, :collection_wrapper_class => "check_boxes" %>
```

and it ignored the class option. I dug into the code and found out that it also requires the tag option to be there.

I think this should be documented.
