### PR TITLE
Output hidden checkbox field after label

### DIFF
--- a/lib/simple_form/inputs/boolean_input.rb
+++ b/lib/simple_form/inputs/boolean_input.rb
@@ -3,10 +3,10 @@ module SimpleForm
     class BooleanInput < Base
       def input
         if nested_boolean_style?
-          build_hidden_field_for_checkbox +
-            template.label_tag(nil, :class => "checkbox") {
-              build_check_box_without_hidden_field + inline_label
-            }
+          template.label_tag(nil, :class => "checkbox") {
+            build_check_box_without_hidden_field + inline_label
+          } +
+            build_hidden_field_for_checkbox
         else
           build_check_box
         end
@@ -19,10 +19,10 @@ module SimpleForm
           html_options = label_html_options.dup
           html_options[:class].push(:checkbox)
 
-          build_hidden_field_for_checkbox +
-            @builder.label(label_target, html_options) {
-              build_check_box_without_hidden_field + label_text
-            }
+          @builder.label(label_target, html_options) {
+            build_check_box_without_hidden_field + label_text
+          } +
+            build_hidden_field_for_checkbox
         else
           input + label
         end

--- a/test/inputs/boolean_input_test.rb
+++ b/test/inputs/boolean_input_test.rb
@@ -47,7 +47,8 @@ class BooleanInputTest < ActionView::TestCase
     swap SimpleForm, :boolean_style => :nested do
       with_input_for @user, :active, :boolean
 
-      assert_select "input[type=hidden][name='user[active]'] + label.boolean > input.boolean"
+      assert_select "label.boolean > input.boolean"
+      assert_select "label.boolean + input[type=hidden][name='user[active]']"
       assert_no_select 'input[type=checkbox] + label'
     end
   end
@@ -56,7 +57,8 @@ class BooleanInputTest < ActionView::TestCase
     swap SimpleForm, :boolean_style => :nested do
       with_input_for @user, :active, :boolean, :disabled => true
 
-      assert_select "input[type=hidden][name='user[active]'][disabled] + label.boolean > input.boolean[disabled]"
+      assert_select "label.boolean > input.boolean[disabled]"
+      assert_select "label.boolean + input[type=hidden][name='user[active]'][disabled]"
     end
   end
 
@@ -98,7 +100,8 @@ class BooleanInputTest < ActionView::TestCase
       swap SimpleForm, :boolean_style => :nested do
         with_input_for @user, :active, :boolean
 
-        assert_select 'label.boolean + input[type=hidden] + label.checkbox > input.boolean'
+        assert_select 'label.boolean + label.checkbox + input[type=hidden]'
+        assert_select 'label.checkbox > input.boolean'
       end
     end
   end
@@ -108,7 +111,8 @@ class BooleanInputTest < ActionView::TestCase
       swap SimpleForm, :boolean_style => :nested do
         with_input_for @user, :active, :boolean
 
-        assert_select 'input[type=hidden] + label.boolean.checkbox > input.boolean'
+        assert_select 'label.boolean.checkbox + input[type=hidden]'
+        assert_select 'label.boolean.checkbox > input.boolean'
       end
     end
   end


### PR DESCRIPTION
This fixes the appearance of bootstrap checkboxes, which require .checkbox to be the first-child of .controls. Without this patch, the following bootstrap style does not get applied:

``` css
.controls > .radio:first-child, .controls > .checkbox:first-child {
  padding-top: 5px;
}
```
