### PR TITLE
Add option to select which attribute contains the error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 pkg/
 rdoc/
 gemfiles/*.lock
+.idea
+.rvmrc

--- a/lib/simple_form/components/errors.rb
+++ b/lib/simple_form/components/errors.rb
@@ -24,11 +24,11 @@ module SimpleForm
       end
 
       def errors_on_attribute
-        object.errors[attribute_name]
+        object.errors[options[:error_attribute] || attribute_name]
       end
 
       def errors_on_association
-        reflection ? object.errors[reflection.name] : []
+        reflection ? object.errors[options[:error_attribute] || reflection.name] : []
       end
     end
   end


### PR DESCRIPTION
In case the attribute which is used for the input field is not the same which gets validated I added an option :error_attribute which is used in the errors component.
