### PR TITLE
Override the attribute errors are gotten from.

### DIFF
--- a/lib/simple_form/components/errors.rb
+++ b/lib/simple_form/components/errors.rb
@@ -24,11 +24,11 @@ module SimpleForm
       end
 
       def errors_on_attribute
-        object.errors[attribute_name]
+        object.errors[options[:error_attribute] || attribute_name]
       end
-
+ 
       def errors_on_association
-        reflection ? object.errors[reflection.name] : []
+        reflection ? object.errors[options[:error_attribute] || reflection.name] : []
       end
     end
   end


### PR DESCRIPTION
Allows for passing an :error_attribute in case you want errors to show up that are 'filed' under a different method than the one passed to the input.

Ex:
 = f.input :skill_token, as: :text, input_html: { class: 'chosen' }, error_attribute: :skill
