### PR TITLE
Twitter bootstrap compatibility

### DIFF
--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -121,6 +121,7 @@ module SimpleForm
         html_options = options[:"#{namespace}_html"]
         html_options = html_options ? html_options.dup : {}
         css_classes << html_options[:class] if html_options.key?(:class)
+        css_classes << "span#{options[:span]}" if options[:span] && namespace == :input 
         html_options[:class] = css_classes unless css_classes.empty?
         html_options
       end


### PR DESCRIPTION
Twitter bootstrap forces all input fields to be the same length. 
With this change, adding :span to your input form forces it to a certain span length. 
span lengths should be responsive. 

e.g. 
<%= f.input :name, :label => 'Name', :span=>5 %>

I guess I could use the input_html tag, but it makes the source cluttered. 
