### PR TITLE
Adds an override to simple_form default classes.

### DIFF
--- a/lib/simple_form/action_view_extensions/form_helper.rb
+++ b/lib/simple_form/action_view_extensions/form_helper.rb
@@ -24,7 +24,7 @@ module SimpleForm
           options[:html][:novalidate] = !SimpleForm.browser_validations
         end
         if options[:html].key?(:only_class)
-          options[:class] = options[:html].delete(:only_class)
+          options[:html][:class] = options[:html].delete(:only_class)
           class_array = []
         else
           class_array = [SimpleForm.form_class]

--- a/test/action_view_extensions/form_helper_test.rb
+++ b/test/action_view_extensions/form_helper_test.rb
@@ -79,6 +79,12 @@ class FormHelperTest < ActionView::TestCase
     assert_select 'form.my_class'
   end
 
+  test 'SimpleForm should remove the default class add custom class to form if css_only_class is specified' do
+    with_concat_form_for(:user, :html => {:only_class => 'my_class'})
+    assert_no_select 'form.simple_form'
+    assert_select 'form.my_class'
+  end
+
   test 'pass options to SimpleForm' do
     with_concat_form_for(:user, :url => '/account', :html => { :id => 'my_form' })
     assert_select 'form#my_form'


### PR DESCRIPTION
There was a use case where I was using Twitter Bootstrap and wanted it to default to using `.form-horizontal` most of the time so I put set `config.form_class = 'simple_form form-horizontal'`. There were odd occasions where I didn't wan't this class set though, so I have added a mechanism where by you can use `:only_class` instead of `:class` in `simple_form_for` and it will completely replace any default classes. 
