### PR TITLE
Adding extra example for f.association

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,12 +301,6 @@ Now we have the user form:
 <% end %>
 ```
 
-In case you want to declare different labels and values:
-
-```ruby
-f.association :company, :label_method => :company_name, :value_method => :id, :include_blank => false %>
-```
-
 Simple enough, right? This is going to render a `:select` input for choosing the `:company`, and another
 `:select` input with `:multiple` option for the `:roles`. You can, of course, change it to use radio
 buttons and check boxes as well:
@@ -322,6 +316,12 @@ the collection by hand, all together with the prompt:
 
 ```ruby
 f.association :company, :collection => Company.active.all(:order => 'name'), :prompt => "Choose a Company"
+```
+
+In case you want to declare different labels and values:
+
+```ruby
+f.association :company, :label_method => :company_name, :value_method => :id, :include_blank => false %>
 ```
 
 ### Buttons


### PR DESCRIPTION
This pull add an example for f.association using the :label_method and :value_method in the README.md :

In case you want to declare different labels and values:

``` ruby
f.association :company, :label_method => :company_name, :value_method => :id, :include_blank => false %>
```
