### PR TITLE
Add rendering check for namespaced  components

### DIFF
--- a/lib/simple_form/wrappers/many.rb
+++ b/lib/simple_form/wrappers/many.rb
@@ -21,16 +21,18 @@ module SimpleForm
       end
 
       def render(input)
-        content = "".html_safe
-        options = input.options
+        if should_render?(input)
+          content = "".html_safe
+          options = input.options
 
-        components.each do |component|
-          next if options[component] == false
-          rendered = component.respond_to?(:render) ? component.render(input) : input.send(component)
-          content.safe_concat rendered.to_s if rendered
+          components.each do |component|
+            next if options[component] == false
+            rendered = component.respond_to?(:render) ? component.render(input) : input.send(component)
+            content.safe_concat rendered.to_s if rendered
+          end
+
+          wrap(input, options, content)
         end
-
-        wrap(input, options, content)
       end
 
       def find(name)
@@ -48,6 +50,11 @@ module SimpleForm
       end
 
       private
+
+      def should_render?(input)
+        return true unless (namespace && input.respond_to?(namespace))
+        input.send(namespace).present?
+      end
 
       def wrap(input, options, content)
         return content if options[namespace] == false

--- a/test/form_builder/wrapper_test.rb
+++ b/test/form_builder/wrapper_test.rb
@@ -200,4 +200,18 @@ class WrapperTest < ActionView::TestCase
       end
     end
   end
+
+  test 'namespaced components when the input responds to namespace and returns nil' do
+    swap_wrapper :default, self.custom_wrapper_with_namespaced_component do
+      with_form_for @user, :active
+      assert_no_select "div.error"
+    end
+  end
+
+  test 'namespaced components when the input either does not respond to namespace or it is not nil' do
+    swap_wrapper :default, self.custom_wrapper_with_namespaced_component do
+      with_form_for @user, :name
+      assert_select "div.error"
+    end
+  end
 end

--- a/test/support/misc_helpers.rb
+++ b/test/support/misc_helpers.rb
@@ -90,6 +90,15 @@ module MiscHelpers
     end
   end
 
+  def custom_wrapper_with_namespaced_component
+    SimpleForm.build :tag => :div, :class => "custom_wrapper" do |b|
+      b.use :input
+      b.wrapper :error, :tag => :div, :class => 'error' do |component|
+        component.use :error
+      end
+    end
+  end
+
   def custom_form_for(object, *args, &block)
     simple_form_for(object, *(args << { :builder => CustomFormBuilder }), &block)
   end


### PR DESCRIPTION
given a namespaced, complex wrapper:

```
b.wrapper :error, :tag => 'div', :class => 'tooltip' do |tip|
  e.wrapper :tag => 'div', :class => 'inner' do |inner|
    inner.use :error, :wrap_with => {
      :tag => 'span',
      :class => 'error'
    }
  end
end
```

if input responds to the namespace and it responds **with** nil, the entire component will not be rendered.

without this change, the following html would be rendered when there is no error:

```
<div class="tooltip">
  <div class="inner"></div>
</div>
```

with this change, `input.error` will respond with `nil` when there are no errors and the error/tooltip html will not, therefore, be rendered.
