### PR TITLE
CSS class for buttons in Foundation 3

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form_foundation.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_foundation.rb
@@ -15,6 +15,9 @@ SimpleForm.setup do |config|
     # b.use :hint,  :wrap_with => { :tag => :span, :class => :hint }
   end
 
+  # CSS class for buttons
+  config.button_class = 'button'
+
   # CSS class to add for error notification helper.
   config.error_notification_class = 'alert-box alert'
 


### PR DESCRIPTION
The CSS class for buttons in Foundation should be `button` ([see Foundation docs](http://foundation.zurb.com/docs/buttons.php)).

Refs #681.
