### PR TITLE
Defaults passed to simple_form_for should propagate to input_field

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -134,6 +134,8 @@ module SimpleForm
     def input_field(attribute_name, options={})
       options = options.dup
       options[:input_html] = options.except(:as, :collection, :label_method, :value_method)
+      options = @defaults.deep_dup.deep_merge(options) if @defaults
+
       SimpleForm::Wrappers::Root.new([:input], :wrapper => false).render find_input(attribute_name, options)
     end
 


### PR DESCRIPTION
This pull request fixes the issue as described in #712
