### PR TITLE
some problems with transfer options

### DIFF
--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -192,17 +192,13 @@ module SimpleForm
       #       posts_form.input :title
       #     end
       #   end
-      def simple_fields_for(*args, &block)
-        options = args.extract_options!
-        options[:wrapper]  ||= self.options[:wrapper]
-        options[:defaults] ||= self.options[:defaults]
-
+      def simple_fields_for(record_name, record_object = nil, options = {}, &block)
         if self.class < ActionView::Helpers::FormBuilder
           options[:builder] ||= self.class
         else
           options[:builder] ||= SimpleForm::FormBuilder
         end
-        fields_for(*(args << options), &block)
+        fields_for(record_name, record_object, options, &block)
       end
 
       private


### PR DESCRIPTION
simple_fields_for don't passed options and it's created some problems like this:
https://github.com/ryanb/nested_form/issues/219
https://github.com/ryanb/nested_form/pull/226

Now all's ok

p.s. link to native method
https://github.com/rails/rails/blob/beba8267c96a3dbc1f505ecc099dbf14db8dde4c/actionpack/lib/action_view/helpers/form_helper.rb#L605
