### PR TITLE
some problems with transfer options

### DIFF
--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -194,7 +194,9 @@ module SimpleForm
       #   end
       def simple_fields_for(*args, &block)
         options = args.extract_options!
-        options[:wrapper]  ||= self.options[:wrapper]
+        if options[:wrapper].nil?
+          options[:wrapper] = self.options[:wrapper]
+        end
         options[:defaults] ||= self.options[:defaults]
 
         if self.class < ActionView::Helpers::FormBuilder


### PR DESCRIPTION
simple_fields_for don't passed options and it's created some problems like this:
ryanb/nested_form#219
ryanb/nested_form#226

because if wrapper option is false, then wrapper not transfered
