### PR TITLE
Display field name in errors w/ config.wrapper option :prefix_attribute_name

### DIFF
--- a/lib/simple_form/components/errors.rb
+++ b/lib/simple_form/components/errors.rb
@@ -12,7 +12,7 @@ module SimpleForm
       protected
 
       def error_text
-        "#{options[:error_prefix]} #{errors.send(error_method)}".lstrip.html_safe
+        "#{options[:error_prefix]} #{attribute_name.to_s.humanize if options[:prefix_attribute_name]} #{errors.send(error_method)}".lstrip.html_safe
       end
 
       def error_method


### PR DESCRIPTION
This adds the ability to prefix error messages through a config.wrapper option `:prefix_attribute_name`.
