### PR TITLE
enable mapping with scope resolution operators to be loaded

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -571,7 +571,7 @@ module SimpleForm
       return if SimpleForm.inputs_discovery == false && at == Object
 
       begin
-        at.const_get(mapping)
+        mapping.split("::").reduce(at){|memo, i| memo.const_get(i)}
       rescue NameError => e
         raise if e.message !~ /#{mapping}$/
       end


### PR DESCRIPTION
It was hard (impossible) for me to override item_wrapper_class for those radio inputs. So this is how I'd monkey patch.

user can extend (monkey patch) built in inputs.
# form.rb

<%= simple_form_for ... do |f| %>
  <%= f.input :bam, as: "extension/collection_radio_buttons" %>
# lib/inputs.rb

module Extension
  class CollectionRadioButtonsInput < SimpleForm::Inputs::CollectionRadioButtonsInput
  protected
    def item_wrapper_class
      # go crazy ...
    end
  end
end
