### PR TITLE
Add Code Climate badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SimpleForm - Rails forms made easy.
 [![Build Status](https://secure.travis-ci.org/plataformatec/simple_form.png?branch=master)](http://travis-ci.org/plataformatec/simple_form)
-[![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/plataformatec/simple_form)
+[![Code Climate](https://codeclimate.com/github/plataformatec/simple_form.png)](https://codeclimate.com/github/plataformatec/simple_form)
 
 **SimpleForm** aims to be as flexible as possible while helping you with powerful components to create
 your forms. The basic goal of SimpleForm is to not touch your way of defining the layout, letting


### PR DESCRIPTION
Hey,

Just wanted to drop you a note to let you know that someone added simple_form to Code Climate a while back. I'm the guy who built Code Climate, and it provides quality metrics for Ruby code, and made it completely free for OSS projects as a way to support them (like GitHub does).

The code quality reports live here:

https://codeclimate.com/github/plataformatec/simple_form

Also, we just launched fancy, dynamic badges for OSS projects.

In case you want this information to be available to contributors, this just adds a badge to the README (similar to Travis) that displays simple_form's quality GPA.

Let me know if you have any questions. Hope you find Code Climate useful.

Cheers,

-Bryan
