### PR TITLE
Include license type in gemspec for auditing tools

### DIFF
--- a/simple_form.gemspec
+++ b/simple_form.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/plataformatec/simple_form"
   s.description = "Forms made easy!"
   s.authors     = ['José Valim', 'Carlos Antônio', 'Rafael França']
+  s.license     = "MIT"
 
   s.files         = Dir["CHANGELOG.md", "MIT-LICENSE", "README.md", "lib/**/*"]
   s.test_files    = Dir["test/**/*.rb"]


### PR DESCRIPTION
We're using http://licenseaudit.pivotallabs.com/ to audit our gem dependencies and it works a lot better when the license is listed in the gemspec
