### PR TITLE
Relation#all is deprecated in Rails 4, use Relation#to_a instead

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -180,7 +180,7 @@ module SimpleForm
 
       options[:as] ||= :select
       options[:collection] ||= options.fetch(:collection) {
-        reflection.klass.where(reflection.options.fetch(:conditions)).order(reflection.options.fetch(:order)).to_a
+        reflection.klass.where(reflection.options[:conditions]).order(reflection.options[:order]).to_a
       }
 
       attribute = case reflection.macro

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -7,22 +7,37 @@ class Column < Struct.new(:name, :type, :limit)
   end
 end
 
+class RelationArray < Array
+  def order(order='')
+    return [last] if order.present?
+    self
+  end
+end
+
 class Company < Struct.new(:id, :name)
   extend ActiveModel::Naming
   include ActiveModel::Conversion
 
-  def self.where(options={})
-    all = (1..3).map{|i| Company.new(i, "Company #{i}")}
-    return [all.first] if options[:conditions].present?
-    return [all.last]  if options[:order].present?
-    return all[0..1] if options[:include].present?
-    return all[1..2] if options[:joins].present?
+  def self.where(conditions={})
+    return RelationArray.new([all.first]) if conditions.present?
+    all
+  end
+
+  def self.includes(includes=[])
+    return RelationArray.new([all[0..1]]) if includes.present?
+    all
+  end
+
+  def self.joins(joins=[])
+    return RelationArray.new([all[1..2]]) if joins.present?
     all
   end
 
   ###just simple Relation#all
   def self.all
-    (1..3).map{|i| Company.new(i, "Company #{i}")}
+    all = RelationArray.new
+    (1..3).map{|i| all << Company.new(i, "Company #{i}")}
+    all
   end
 
   def self.merge_conditions(a, b)
@@ -35,8 +50,15 @@ class Company < Struct.new(:id, :name)
 end
 
 class Tag < Company
-  def self.where(options={})
+  def self.all
     (1..3).map{|i| Tag.new(i, "Tag #{i}")}
+  end
+
+  def self.where(conditions={})
+    all = RelationArray.new
+    (1..3).map{|i| all << Tag.new(i, "Tag #{i}")}
+    return RelationArray.new(all.first) if conditions.present?
+    all
   end
 end
 


### PR DESCRIPTION
When I use simple_form with association, got a warning :

```
DEPRECATION WARNING: Relation#all is deprecated. If you want to eager-load a relation, you can call #load (e.g. `Post.where(published: true).load`). If you want to get an array of records from a relation, you can call #to_a (e.g. `Post.where(published: true).to_a`).
```

so maybe it's a good time to make this small adjustment ?
