### PR TITLE
Fix boolean input with nested style when using bootstrap

### DIFF
--- a/lib/simple_form/inputs/boolean_input.rb
+++ b/lib/simple_form/inputs/boolean_input.rb
@@ -3,10 +3,10 @@ module SimpleForm
     class BooleanInput < Base
       def input
         if nested_boolean_style?
-          build_hidden_field_for_checkbox +
-            template.label_tag(nil, class: "checkbox") {
+          template.label_tag(nil, class: "checkbox") {
+            build_hidden_field_for_checkbox +
               build_check_box_without_hidden_field + inline_label
-            }
+          }
         else
           build_check_box
         end

--- a/test/inputs/boolean_input_test.rb
+++ b/test/inputs/boolean_input_test.rb
@@ -123,7 +123,8 @@ class BooleanInputTest < ActionView::TestCase
       swap SimpleForm, boolean_style: :nested do
         with_input_for @user, :active, :boolean
 
-        assert_select 'label.boolean + input[type=hidden] + label.checkbox > input.boolean'
+        assert_select 'label.boolean + label.checkbox > input.boolean'
+        assert_select 'label.boolean + label.checkbox > input[type=hidden]'
       end
     end
   end


### PR DESCRIPTION
move hidden field into label.checkbox, as it broke this rule in bootstrap:

``` css
.controls>.radio:first-child, .controls>.checkbox:first-child {
  padding-top: 5px;
}
```
