### PR TITLE
Change initializer config.browser_validations comment

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb
@@ -107,7 +107,8 @@ SimpleForm.setup do |config|
   # config.required_by_default = true
 
   # Tell browsers whether to use default HTML5 validations (novalidate option).
-  # Default is false (disabled) because browser validations are not easily configurable
+  # To restore the default (enabled), comment the below line or change it to true
+  # However false is recommmended because simple_form can't control their behavior
   config.browser_validations = false
 
   # Collection of methods to detect if a file type was given.


### PR DESCRIPTION
This comment used to say Default is enabled, which makes no sense, since the default is actually disabling browser validations. This text is less confusing imho.
