### PR TITLE
Consider whether the user explicitly specifies a label when applying global custom formatting

### DIFF
--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -66,7 +66,7 @@ module SimpleForm
 
   # How the label text should be generated altogether with the required text.
   mattr_accessor :label_text
-  @@label_text = lambda { |label, required| "#{required} #{label}" }
+  @@label_text = proc { |label, required| "#{required} #{label}" }
 
   # You can define the class to be used on all labels. Defaults to none.
   mattr_accessor :label_class

--- a/lib/simple_form/components/labels.rb
+++ b/lib/simple_form/components/labels.rb
@@ -30,11 +30,7 @@ module SimpleForm
       end
 
       def label_text
-        @label_text_extended ||= SimpleForm.label_text.parameters.size == 3
-        (@label_text_extended ?
-          SimpleForm.label_text.call(raw_label_text, required_label_text, options[:label].present?) :
-          SimpleForm.label_text.call(raw_label_text, required_label_text))
-        .strip.html_safe
+        SimpleForm.label_text.call(raw_label_text, required_label_text, options[:label].present?).strip.html_safe
       end
 
       def label_target

--- a/test/form_builder/label_test.rb
+++ b/test/form_builder/label_test.rb
@@ -63,21 +63,21 @@ class LabelTest < ActionView::TestCase
   end
 
   test 'builder allows label order to be changed' do
-    swap SimpleForm, label_text: lambda { |l, r| "#{l}:" } do
+    swap SimpleForm, label_text: proc { |l, r| "#{l}:" } do
       with_label_for @user, :age
       assert_select 'label.integer[for=user_age]', "Age:"
     end
   end
 
   test 'builder should allow custom formatting when label is explicitly specified' do
-    swap SimpleForm, label_text: lambda {|l, r, explicit| explicit ? l : "#{l.titleize}:" } do
+    swap SimpleForm, label_text: proc {|l, r, explicit| explicit ? l : "#{l.titleize}:" } do
       with_label_for @user, :time_zone, 'What is your home time zone?'
       assert_select 'label[for=user_time_zone]', 'What is your home time zone?'
     end
   end
 
   test 'builder should allow custom formatting when label is generated' do
-    swap SimpleForm, label_text: lambda {|l, r, explicit| explicit ? l : "#{l.titleize}:" } do
+    swap SimpleForm, label_text: proc {|l, r, explicit| explicit ? l : "#{l.titleize}:" } do
       with_label_for @user, :time_zone
       assert_select 'label[for=user_time_zone]', 'Time Zone:'
     end


### PR DESCRIPTION
Let's say I want to titleize my generated labels.  I can do it:

``` ruby
config.label_text = lambda { |label, required| "#{label.titleize}" }
```

But then I can't have a non titled label, even if I specify it.  This:

``` ruby
<%= f.input :distributor, label: 'Who provides your cable or satellite service?' %>
```

Will generate this label: `Who Provides Your Cable Or Satellite Service?`

Yeah, ugly.  It's not what I want, and there's no way to handle it (except maybe with undesirable options like #human_attribute_name or by replacing a major part of the framework.)

This PR is a simple solution that does not break existing code.
