### PR TITLE
simplify unsplatting syntax

### DIFF
--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -23,7 +23,7 @@ module SimpleForm
         else
           options[:builder] ||= SimpleForm::FormBuilder
         end
-        fields_for(*(args << options), &block)
+        fields_for(*args, options, &block)
       end
     end
   end

--- a/test/support/misc_helpers.rb
+++ b/test/support/misc_helpers.rb
@@ -113,11 +113,11 @@ module MiscHelpers
   end
 
   def custom_form_for(object, *args, &block)
-    simple_form_for(object, *(args << { builder: CustomFormBuilder }), &block)
+    simple_form_for(object, *args, { builder: CustomFormBuilder }, &block)
   end
 
   def custom_mapping_form_for(object, *args, &block)
-    simple_form_for(object, *(args << { builder: CustomMapTypeFormBuilder }), &block)
+    simple_form_for(object, *args, { builder: CustomMapTypeFormBuilder }, &block)
   end
 
   def with_concat_form_for(*args, &block)
@@ -151,7 +151,7 @@ end
 
 class CustomFormBuilder < SimpleForm::FormBuilder
   def input(attribute_name, *args, &block)
-    super(attribute_name, *(args << { input_html: { class: 'custom' } }), &block)
+    super(attribute_name, *args, { input_html: { class: 'custom' } }, &block)
   end
 end
 


### PR DESCRIPTION
Unnecessary complex code simplified a bit.
If anyone can test it on ruby 1.8, please do it. I've tested it on 1.9.3p0 and 2.0.0p0 
