### PR TITLE
Use Orm Adapter gem to handle conditions/order from associations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     simple_form (3.0.0.beta1)
       actionpack (>= 4.0.0.rc1, < 4.1)
       activemodel (>= 4.0.0.rc1, < 4.1)
+      orm_adapter (~> 0.4.0)
 
 GEM
   remote: https://rubygems.org/
@@ -31,6 +32,7 @@ GEM
     json (1.7.7)
     minitest (4.7.4)
     multi_json (1.7.2)
+    orm_adapter (0.4.0)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -1,4 +1,5 @@
 require 'action_view'
+require 'orm_adapter'
 require 'simple_form/action_view_extensions/form_helper'
 require 'simple_form/action_view_extensions/builder'
 require 'active_support/core_ext/hash/slice'

--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -180,7 +180,7 @@ module SimpleForm
 
       options[:as] ||= :select
       options[:collection] ||= options.fetch(:collection) {
-        reflection.klass.all(reflection.options.slice(:conditions, :order))
+        reflection.klass.to_adapter.find_all(reflection.options.slice(:conditions, :order))
       }
 
       attribute = case reflection.macro

--- a/simple_form.gemspec
+++ b/simple_form.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency('activemodel', '>= 4.0.0.rc1', '< 4.1')
   s.add_dependency('actionpack', '>= 4.0.0.rc1', '< 4.1')
+  s.add_dependency('orm_adapter', '~> 0.4.0')
 end

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -1,3 +1,15 @@
+Adapter = Struct.new(:all) do
+  def find_all(options)
+    if options[:conditions]
+      [all.first]
+    elsif options[:order]
+      [all.last]
+    else
+      all
+    end
+  end
+end
+
 Association = Struct.new(:klass, :name, :macro, :options)
 
 Column = Struct.new(:name, :type, :limit) do
@@ -12,15 +24,11 @@ Company = Struct.new(:id, :name) do
   include ActiveModel::Conversion
 
   def self.all(options={})
-    all = (1..3).map { |i| Company.new(i, "Company #{i}") }
+    (1..3).map { |i| new(i, "#{name} #{i}") }
+  end
 
-    if options[:conditions]
-      [all.first]
-    elsif options[:order]
-      [all.last]
-    else
-      all
-    end
+  def self.to_adapter
+    Adapter.new all
   end
 
   def persisted?
@@ -28,11 +36,7 @@ Company = Struct.new(:id, :name) do
   end
 end
 
-class Tag < Company
-  def self.all(options={})
-    (1..3).map { |i| Tag.new(i, "Tag #{i}") }
-  end
-end
+class Tag < Company; end
 
 TagGroup = Struct.new(:id, :name, :tags)
 


### PR DESCRIPTION
This would be an approach using Orm Adapter to handle the relation query in Simple Form.

But, after finishing that, it came to my mind that actually passing options as a hash in associations is deprecated in Active Record, isn't it?

If it is, I'd rather stop supporting this way and just load the relation, which should apply its own conditions instead of doing that ourselves. We can figure what needs to be done with mongoid later if needed.

Thoughts?

Related to #759.
