### PR TITLE
input without additional classes should not add "checkbox" class to label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   * `input_field` supports `html5` component [@nashby](https://github.com/nashby)
 
 ### bug fix
+  * Add "checkbox" class to the label of boolean input when there is no `:label`
+  in `generate_additional_classes_for` config option [@nashby](https://github.com/nashby)
   * Support models with digits in their names [@webgago](https://github.com/webgago)
 
 ## 3.0.0.rc

--- a/lib/simple_form/inputs/boolean_input.rb
+++ b/lib/simple_form/inputs/boolean_input.rb
@@ -17,6 +17,7 @@ module SimpleForm
           input
         elsif nested_boolean_style?
           html_options = label_html_options.dup
+          html_options[:class] ||= []
           html_options[:class].push(:checkbox)
 
           build_hidden_field_for_checkbox +

--- a/test/inputs/boolean_input_test.rb
+++ b/test/inputs/boolean_input_test.rb
@@ -137,4 +137,16 @@ class BooleanInputTest < ActionView::TestCase
       end
     end
   end
+
+  test 'input boolean without additional classes should add "checkbox" class to label' do
+    swap_wrapper :default, self.custom_wrapper_without_top_level do
+      swap SimpleForm, boolean_style: :nested, generate_additional_classes_for: [:input] do
+        with_input_for @user, :active, :boolean
+
+        assert_select 'label'
+        assert_select 'label.checkbox'
+        assert_no_select 'label.boolean'
+      end
+    end
+  end
 end


### PR DESCRIPTION
we should not add checkbox class to the component that is not in `generate_additional_classes_for`, right?

closes #809
