### PR TITLE
Don't load association collection until needed

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -184,7 +184,7 @@ module SimpleForm
       options[:collection] ||= options.fetch(:collection) {
         conditions = reflection.options[:conditions]
         conditions = conditions.call if conditions.respond_to?(:call)
-        reflection.klass.where(conditions).order(reflection.options[:order]).to_a
+        reflection.klass.where(conditions).order(reflection.options[:order])
       }
 
       attribute = case reflection.macro


### PR DESCRIPTION
Hi,

I was creating a custom collection input, when I figured that the collection passed to the input object is already an array.

Passing a AR::Relation (or any other ORM relation) instead of an array will prevent loading the whole table before rendering the input.

In my case, I'm building an input with autocompletion. I need the `CollectionInput` design, but not loading the whole table.

It should not affect default inputs provided by simple_form : to_a will be called in `SimpleForm::Inputs::CollectionInput # collection`

The patch is really tiny, and all tests passed.
