### PR TITLE
collection tags accept html attributes as the last element of collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## master
 
 ### enhancements
+  * Collection tags accept html attributes as the last element of collection [@nashby](https://github.com/nashby)
+  * Change default `:value_method` of collection tags from `:last` to `:second` [@nashby](https://github.com/nashby)
   * Support `Proc` object in `:conditions` option of associations [@bradly](https://github.com/bradly)
   * `input_field` supports `html5` component [@nashby](https://github.com/nashby)
 

--- a/lib/simple_form/inputs/collection_input.rb
+++ b/lib/simple_form/inputs/collection_input.rb
@@ -66,7 +66,7 @@ module SimpleForm
         collection_translated = translate_collection if collection_classes == [Symbol]
 
         if collection_translated || collection_classes.include?(Array)
-          { label: :first, value: :last }
+          { label: :first, value: :second }
         elsif collection_includes_basic_objects?(collection_classes)
           { label: :to_s, value: :to_s }
         else

--- a/lib/simple_form/tags.rb
+++ b/lib/simple_form/tags.rb
@@ -11,8 +11,9 @@ module SimpleForm
           value = value_for_collection(item, @value_method)
           text  = value_for_collection(item, @text_method)
           default_html_options = default_html_options_for_collection(item, value)
+          additional_html_options = option_html_attributes(item)
 
-          rendered_item = yield item, value, text, default_html_options
+          rendered_item = yield item, value, text, default_html_options.merge(additional_html_options)
 
           item_wrapper_tag ? @template_object.content_tag(item_wrapper_tag, rendered_item, class: item_wrapper_class) : rendered_item
         end.join.html_safe

--- a/test/inputs/collection_check_boxes_input_test.rb
+++ b/test/inputs/collection_check_boxes_input_test.rb
@@ -60,6 +60,11 @@ class CollectionCheckBoxesInputTest < ActionView::TestCase
     assert_no_select 'form ul'
   end
 
+  test 'input check boxes accepts html options as the last element of collection' do
+    with_input_for @user, :name, :check_boxes, collection: [['Jose', 'jose', class: 'foo']]
+    assert_select 'input.foo[type=checkbox][value=jose]'
+  end
+
   test 'input check boxes wraps the collection in the configured collection wrapper tag' do
     swap SimpleForm, collection_wrapper_tag: :ul do
       with_input_for @user, :active, :check_boxes

--- a/test/inputs/collection_radio_buttons_input_test.rb
+++ b/test/inputs/collection_radio_buttons_input_test.rb
@@ -82,6 +82,11 @@ class CollectionRadioButtonsInputTest < ActionView::TestCase
     assert_select 'input[type=radio][value=Carlos][checked=checked]'
   end
 
+  test 'input should accept html options as the last element of collection' do
+    with_input_for @user, :name, :radio_buttons, collection: [['Jose', 'jose', class: 'foo']]
+    assert_select 'input.foo[type=radio][value=jose]'
+  end
+
   test 'input should allow using a collection with text/value arrays' do
     with_input_for @user, :name, :radio_buttons, collection: [['Jose', 'jose'], ['Carlos', 'carlos']]
     assert_select 'input[type=radio][value=jose]'

--- a/test/inputs/collection_select_input_test.rb
+++ b/test/inputs/collection_select_input_test.rb
@@ -56,6 +56,12 @@ class CollectionSelectInputTest < ActionView::TestCase
     assert_select 'select option[selected=selected]', 'Carlos'
   end
 
+  test 'input should accept html options as the last element of collection' do
+    with_input_for @user, :name, :select, collection: [['Jose', class: 'foo']]
+    assert_select 'select.select#user_name'
+    assert_select 'select option.foo', 'Jose'
+  end
+
   test 'input should mark the selected value also when using integers' do
     @user.age = 18
     with_input_for @user, :age, :select, collection: 18..60


### PR DESCRIPTION
But if want to use this feature right now we have to specify `label_method` and `value_method` as `:first` and `:second` since `:last` method uses by default for `value_method` and it's not good for us. Actually, we can change default behaviour to `:second` as the `value_method` but I think it can break someone's code. Any idea?
