### PR TITLE
Update to Rails 4 release.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,9 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'country_select', '~> 1.1.1'
-gem 'railties', '>= 4.0.0.rc1', '< 4.1'
-gem 'activemodel', '>= 4.0.0.rc1', '< 4.1'
-gem 'actionpack', '>= 4.0.0.rc1', '< 4.1'
+gem 'railties', '>= 4.0.0', '< 4.1'
+gem 'activemodel', '>= 4.0.0', '< 4.1'
+gem 'actionpack', '>= 4.0.0', '< 4.1'
 gem 'rake'
 gem 'rdoc'
 gem 'tzinfo'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,41 +2,41 @@ PATH
   remote: .
   specs:
     simple_form (3.0.0.rc)
-      actionpack (>= 4.0.0.rc1, < 4.1)
-      activemodel (>= 4.0.0.rc1, < 4.1)
+      actionpack (>= 4.0.0, < 4.1)
+      activemodel (>= 4.0.0, < 4.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (4.0.0.rc1)
-      activesupport (= 4.0.0.rc1)
+    actionpack (4.0.0)
+      activesupport (= 4.0.0)
       builder (~> 3.1.0)
       erubis (~> 2.7.0)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
-    activemodel (4.0.0.rc1)
-      activesupport (= 4.0.0.rc1)
+    activemodel (4.0.0)
+      activesupport (= 4.0.0)
       builder (~> 3.1.0)
-    activesupport (4.0.0.rc1)
+    activesupport (4.0.0)
       i18n (~> 0.6, >= 0.6.4)
       minitest (~> 4.2)
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
-    atomic (1.1.8)
+    atomic (1.1.9)
     builder (3.1.4)
     country_select (1.1.3)
     erubis (2.7.0)
     i18n (0.6.4)
     json (1.7.7)
-    minitest (4.7.4)
-    multi_json (1.7.2)
+    minitest (4.7.5)
+    multi_json (1.7.7)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
-    railties (4.0.0.rc1)
-      actionpack (= 4.0.0.rc1)
-      activesupport (= 4.0.0.rc1)
+    railties (4.0.0)
+      actionpack (= 4.0.0)
+      activesupport (= 4.0.0)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.0.4)
@@ -51,10 +51,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionpack (>= 4.0.0.rc1, < 4.1)
-  activemodel (>= 4.0.0.rc1, < 4.1)
+  actionpack (>= 4.0.0, < 4.1)
+  activemodel (>= 4.0.0, < 4.1)
   country_select (~> 1.1.1)
-  railties (>= 4.0.0.rc1, < 4.1)
+  railties (>= 4.0.0, < 4.1)
   rake
   rdoc
   simple_form!

--- a/simple_form.gemspec
+++ b/simple_form.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "simple_form"
 
-  s.add_dependency('activemodel', '>= 4.0.0.rc1', '< 4.1')
-  s.add_dependency('actionpack', '>= 4.0.0.rc1', '< 4.1')
+  s.add_dependency('activemodel', '>= 4.0.0', '< 4.1')
+  s.add_dependency('actionpack', '>= 4.0.0', '< 4.1')
 end


### PR DESCRIPTION
Rails 4 has now been released. Unfortunately, the '>= 4.0.0.rc1'
dependency doesn't work with the release.
