### PR TITLE
Note about ORM compatibility for association helper in the README and source

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,8 @@ In case you want to declare different labels and values:
 f.association :company, label_method: :company_name, value_method: :id, include_blank: false
 ```
 
+Please note that the association helper is currently only tested with Active Record. It currently does not work well with Mongoid and depending on the ORM you're using your mileage may vary.
+
 ### Buttons
 
 All web forms need buttons, right? **SimpleForm** wraps them in the DSL, acting like a proxy:

--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -169,6 +169,8 @@ module SimpleForm
     #
     # From the options above, only :collection can also be supplied.
     #
+    # Please note that the association helper is currently only tested with Active Record. Depending on the ORM you are using your mileage may vary.
+    #
     def association(association, options={}, &block)
       options = options.dup
 


### PR DESCRIPTION
Hi,

I tried to use the association helper with Mongoid and got weird exceptions.
I had to search on the Web for half an hour before discovering that the association helper is currently not compatible with Mongoid :(.
As Devise, which is another gem from plataformatec, is compatible with Mongoid, I thought that it was the same for SimpleForm. Since it is not the same, I think there should be a note about that in the README.

Thanks.

Nicolas.
