### PR TITLE
Handle situation when I18n date.order values are strings

### DIFF
--- a/lib/simple_form/inputs/date_time_input.rb
+++ b/lib/simple_form/inputs/date_time_input.rb
@@ -14,7 +14,7 @@ module SimpleForm
           date_order.first
         else
           :hour
-        end
+        end.to_sym
 
         position = ActionView::Helpers::DateTimeSelector::POSITION[position]
         "#{attribute_name}_#{position}i"

--- a/test/inputs/datetime_input_test.rb
+++ b/test/inputs/datetime_input_test.rb
@@ -63,26 +63,26 @@ class DateTimeInputTest < ActionView::TestCase
   end
 
   test 'label should use i18n to get target for date input type' do
-    store_translations(:en, date: { order: [:month, :day, :year] }) do
+    store_translations(:en, date: { order: ['month', 'day', 'year'] }) do
       with_input_for :project, :created_at, :date
       assert_select 'label[for=project_created_at_2i]'
     end
   end
 
   test 'label should use i18n to get target for datetime input type' do
-    store_translations(:en, date: { order: [:month, :day, :year] }) do
+    store_translations(:en, date: { order: ['month', 'day', 'year'] }) do
       with_input_for :project, :created_at, :datetime
       assert_select 'label[for=project_created_at_2i]'
     end
   end
 
   test 'label should use order to get target when date input type' do
-    with_input_for :project, :created_at, :date, order: [:month, :year, :day]
+    with_input_for :project, :created_at, :date, order: ['month', 'year', 'day']
     assert_select 'label[for=project_created_at_2i]'
   end
 
   test 'label should use order to get target when datetime input type' do
-    with_input_for :project, :created_at, :datetime, order: [:month, :year, :day]
+    with_input_for :project, :created_at, :datetime, order: ['month', 'year', 'day']
     assert_select 'label[for=project_created_at_2i]'
   end
 


### PR DESCRIPTION
Rails 4 changes the `date.order` I18n setting to return strings, which
resulted in a missed lookup in POSITION, and a value like `date_i`
instead of `date_1i` for the `for` attribute on `label` elements.
