### PR TITLE
Execute the given Proc condition in the context of the object to allow for dynamic conditions

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -185,7 +185,7 @@ module SimpleForm
       options[:as] ||= :select
       options[:collection] ||= options.fetch(:collection) {
         conditions = reflection.options[:conditions]
-        conditions = conditions.call if conditions.respond_to?(:call)
+        conditions = object.instance_exec(&conditions) if conditions.respond_to?(:call)
         reflection.klass.where(conditions).order(reflection.options[:order])
       }
 

--- a/test/form_builder/association_test.rb
+++ b/test/form_builder/association_test.rb
@@ -113,6 +113,14 @@ class AssociationTest < ActionView::TestCase
     assert_no_select 'form select option[value=3]'
   end
 
+  test 'builder allows collection to have dynamic conditions in proc ' do
+    with_association_for @user, :dynamic_condition_tags
+    assert_select 'form select.select#user_dynamic_condition_tag_ids'
+    assert_select 'form select[multiple=multiple]'
+    assert_select 'form select option[value=1]', '1'
+    assert_no_select 'form select option[value=2]', '2'
+  end
+
   test 'builder marks the record which already belongs to the user' do
     @user.company_id = 2
     with_association_for @user, :company, as: :radio_buttons

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -53,7 +53,7 @@ class User
     :delivery_time, :born_at, :special_company_id, :country, :tags, :tag_ids,
     :avatar, :home_picture, :email, :status, :residence_country, :phone_number,
     :post_count, :lock_version, :amount, :attempts, :action, :credit_card, :gender,
-    :extra_special_company_id
+    :extra_special_company_id, :dynamic_condition_tags, :dynamic_condition_tag_ids
 
   def self.build(extra_attributes = {})
     attributes = {
@@ -133,6 +133,8 @@ class User
         Association.new(Company, association, :belongs_to, { conditions: { id: 1 } })
       when :extra_special_company
         Association.new(Company, association, :belongs_to, { conditions: proc { { id: 1 } } })
+      when :dynamic_condition_tags
+        Association.new(Tag, association, :has_many, { conditions: proc { { id: self.id } } })
     end
   end
 


### PR DESCRIPTION
Hi,
currently the Proc specified in conditions is evaluated in the context of the FormBuilder. it should be evaluated in the context of the object so that conditions that are dependant on the object state can be specified (as it works in active record)

the test example only shows the one tag that has the same id that the user id. a practical example would be if a User and Tag would belongs_to a Group and one would want to scope the show only the Tags from the same group to the user.
