### PR TITLE
default input class (config.input_class)

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb
@@ -139,4 +139,7 @@ SimpleForm.setup do |config|
 
   # Cache SimpleForm inputs discovery
   # config.cache_discovery = !Rails.env.development?
+
+  # Default class for inputs
+  # config.input_class = nil
 end

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -133,6 +133,10 @@ module SimpleForm
   mattr_accessor :button_class
   @@button_class = 'button'
 
+  # Adds a class to each generated inputs
+  mattr_accessor :input_class
+  @@input_class = nil
+
   ## WRAPPER CONFIGURATION
   # The default wrapper to be used by the FormBuilder.
   mattr_accessor :default_wrapper

--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -81,7 +81,7 @@ module SimpleForm
       end
 
       def additional_classes
-        @additional_classes ||= [input_type, required_class, readonly_class, disabled_class].compact
+        @additional_classes ||= [input_type, required_class, readonly_class, disabled_class, SimpleForm.input_class].compact
       end
 
       def input_class

--- a/test/inputs/general_test.rb
+++ b/test/inputs/general_test.rb
@@ -20,6 +20,13 @@ class InputTest < ActionView::TestCase
     assert_select 'input.string[autofocus]'
   end
 
+  test 'input should accepts input class configuration' do
+    swap SimpleForm, :input_class => :xlarge do
+      with_input_for @user, :name, :string
+      assert_select 'input.xlarge'
+    end
+  end
+
   test 'text input should generate autofocus attribute when autofocus option is true' do
     with_input_for @user, :description, :text, :autofocus => true
     assert_select 'textarea.text[autofocus]'


### PR DESCRIPTION
Add support for a default input class under Rails 3.2.
