### PR TITLE
Collection check boxes with name

### DIFF
--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -178,7 +178,8 @@ module SimpleForm
 
         # Append a hidden field to make sure something will be sent back to the
         # server if all checkboxes are unchecked.
-        hidden = @template.hidden_field_tag("#{object_name}[#{attribute}][]", "", :id => nil)
+        hidden_name = html_options[:name] || "#{object_name}[#{attribute}][]"
+        hidden = @template.hidden_field_tag(hidden_name, "", :id => nil)
 
         wrap_rendered_collection(rendered_collection + hidden, options)
       end

--- a/test/action_view_extensions/builder_test.rb
+++ b/test/action_view_extensions/builder_test.rb
@@ -288,6 +288,13 @@ class BuilderTest < ActionView::TestCase
     assert_select "form input[type=hidden][name='user[tag_ids][]'][value=]", :count => 1
   end
 
+  test "collection check box generates a hidden field using the given :name in :input_html" do
+    collection = [Tag.new(1, 'Tag 1'), Tag.new(2, 'Tag 2')]
+    with_collection_check_boxes @user, :tag_ids, collection, :id, :name, {}, {:name => "user[other_tag_ids][]"}
+
+    assert_select "form input[type=hidden][name='user[other_tag_ids][]'][value=]", :count => 1
+  end
+
   test "collection check box accepts a collection and generate a serie of checkboxes with labels for label method" do
     collection = [Tag.new(1, 'Tag 1'), Tag.new(2, 'Tag 2')]
     with_collection_check_boxes @user, :tag_ids, collection, :id, :name


### PR DESCRIPTION
In v2.1, the collection_check_boxes method ignores the :name from :input_html when generating a hidden field. This pull request will use :name if it exists, and use the default otherwise. Test included.
