### PR TITLE
Add method #full_error to SimpleForm::Components::Errors

### DIFF
--- a/lib/simple_form/components/errors.rb
+++ b/lib/simple_form/components/errors.rb
@@ -1,6 +1,18 @@
 module SimpleForm
   module Components
     module Errors
+      def full_error
+        return unless error.present?
+
+        prefix = if object.class.respond_to?(:human_attribute_name)
+          object.class.human_attribute_name(attribute_name.to_s)
+        else
+          attribute_name.to_s.humanize
+        end
+
+        "#{prefix} #{error_text}".html_safe
+      end
+    
       def error
         error_text if has_errors?
       end


### PR DESCRIPTION
So things like

```
b.use :full_error, :wrap_with => { :tag => 'span', :class => 'help-inline' }
```

Can be used

Not idea how to use options like

```
f.input :name, full_error: false 
```

to prevent it from showing
