### PR TITLE
Possibility of specifying additional html attributes to 'wrap'

### DIFF
--- a/lib/simple_form/wrappers/many.rb
+++ b/lib/simple_form/wrappers/many.rb
@@ -62,7 +62,7 @@ module SimpleForm
       end
 
       def html_options(options)
-        options[:"#{namespace}_html"] || {}
+        (@defaults[:html] || {}).update(options[:"#{namespace}_html"] || {})
       end
 
       def html_classes(input, options)


### PR DESCRIPTION
Currently, when specifying a wrapper using the `wrap` method, the only HTML attribute supported is `class`. This simple change allows to specify an additional option named `html` which can contain additional HTML attributes like such:

``` ruby
config.wrappers do |b|
  b.wrapper :tag => :td, :class => :some_class, :html => { :additional_html_attribute => :value }
end
```

I'd love to see this feature in SimpleForm :)
