### PR TITLE
add option to ignore default input class

### DIFF
--- a/lib/simple_form/components.rb
+++ b/lib/simple_form/components.rb
@@ -18,5 +18,6 @@ module SimpleForm
     autoload :Pattern
     autoload :Placeholders
     autoload :Readonly
+    autoload :DefaultInputClass
   end
 end

--- a/lib/simple_form/components/default_input_class.rb
+++ b/lib/simple_form/components/default_input_class.rb
@@ -1,0 +1,11 @@
+module SimpleForm
+  module Components
+    module DefaultInputClass
+      extend ActiveSupport::Concern
+
+      def ignore_default_input_class
+        options[:ignore_default_input_class] == true
+      end
+    end
+  end
+end

--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -20,6 +20,7 @@ module SimpleForm
       include SimpleForm::Components::Pattern
       include SimpleForm::Components::Placeholders
       include SimpleForm::Components::Readonly
+      include SimpleForm::Components::DefaultInputClass
 
       attr_reader :attribute_name, :column, :input_type, :reflection,
                   :options, :input_html_options, :input_html_classes, :html_classes
@@ -65,7 +66,7 @@ module SimpleForm
         @html_classes = SimpleForm.additional_classes_for(:input) { additional_classes }
 
         @input_html_classes = @html_classes.dup
-        if SimpleForm.input_class && !input_html_classes.empty?
+        if SimpleForm.input_class && !input_html_classes.empty?  && !ignore_default_input_class
           input_html_classes << SimpleForm.input_class
         end
 

--- a/test/inputs/general_test.rb
+++ b/test/inputs/general_test.rb
@@ -28,6 +28,13 @@ class InputTest < ActionView::TestCase
     end
   end
 
+  test 'input does not add input_class if ignore_default_input_class option is provided' do
+    swap SimpleForm, input_class: :xlarge do
+      with_input_for @user, :name, :string, ignore_default_input_class: true
+      assert_no_select 'input.xlarge'
+    end
+  end
+
   test 'input does not add input_class when configured to not generate additional classes for input' do
     swap SimpleForm, input_class: 'xlarge', generate_additional_classes_for: [:wrapper] do
       with_input_for @user, :name, :string


### PR DESCRIPTION
The new `input_class` global configuration is really helpful for a Bootstrap 3 app, but gets in the way with checkboxes because they do not like the `form-control` class. See http://getbootstrap.com/css/#forms for an example.

This PR adds a new option to inputs that ignores the default input class.

`= f.input :example_boolean, ignore_default_input_class: true, label: false, inline_label: "Check me?"`
