### PR TITLE
Add bootstrap wrapper for inputs with both prepended and appended text

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
@@ -36,6 +36,19 @@ SimpleForm.setup do |config|
       input.use :error, wrap_with: { tag: 'span', class: 'help-inline' }
     end
   end
+  
+  config.wrappers :prepend_and_append, tag: 'div', class: "control-group", error_class: 'error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.use :label
+    b.wrapper tag: 'div', class: 'controls' do |input|
+      input.wrapper tag: 'div', class: 'input-prepend input-append' do |append|
+        append.use :input
+      end
+      input.use :hint,  wrap_with: { tag: 'span', class: 'help-block' }
+      input.use :error, wrap_with: { tag: 'span', class: 'help-inline' }
+    end
+  end
 
   # Wrappers for forms and inputs using the Twitter Bootstrap toolkit.
   # Check the Bootstrap docs (http://twitter.github.com/bootstrap)


### PR DESCRIPTION
Changes the generated initializer template to include a wrapper for inputs with both prepended and appended text. Use by specifying wrapper: :prepend_and_append in a form.input call.
