### PR TITLE
collection input generates `required` attribute if it has `prompt` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## master
+
+### bug fix
+  * Collection input generates `required` attribute if it has `prompt` option. [@nashby](https://github.com/nashby)
+
 ## 3.0.0
 
 ### enhancements

--- a/lib/simple_form/inputs/collection_input.rb
+++ b/lib/simple_form/inputs/collection_input.rb
@@ -33,7 +33,7 @@ module SimpleForm
       end
 
       def has_required?
-        super && (input_options[:include_blank] || multiple?)
+        super && (input_options[:include_blank] || input_options[:prompt] || multiple?)
       end
 
       # Check if :include_blank must be included by default.

--- a/test/inputs/collection_select_input_test.rb
+++ b/test/inputs/collection_select_input_test.rb
@@ -178,6 +178,12 @@ class CollectionSelectInputTest < ActionView::TestCase
     assert_select 'select[required]'
   end
 
+  test 'collection input with select type should generate required html attribute only with blank option or prompt' do
+    with_input_for @user, :name, :select, prompt: 'Name...', collection: ['Jose', 'Carlos']
+    assert_select 'select.required'
+    assert_select 'select[required]'
+  end
+
   test 'collection input with select type should not generate required html attribute without blank option' do
     with_input_for @user, :name, :select, include_blank: false, collection: ['Jose', 'Carlos']
     assert_select 'select.required'


### PR DESCRIPTION
closes #919
