### PR TITLE
Allow not including input wrapper class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### enhancements
   * Add wrapper mapping per form basis [@rcillo](https://github.com/rcillo) and [@bernardoamc](https://github.com/bernardoamc)
   * Add `for` attribute to `label` when collections are rendered as radio or checkbox [@erichkist](https://github.com/erichkist), [@ulissesalmeida](https://github.com/ulissesalmeida) and [@fabioyamate](https://github.com/fabioyamate)
+  * Add `include_default_input_wrapper_class` config [@luizcosta](https://github.com/luizcosta)
 
 ### bug fix
   * Collection input generates `required` attribute if it has `prompt` option. [@nashby](https://github.com/nashby)

--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb
@@ -142,4 +142,8 @@ SimpleForm.setup do |config|
 
   # Default class for inputs
   # config.input_class = nil
+
+  # Defines if the default input wrapper class should be included in radio
+  # collection wrappers.
+  # config.include_default_input_wrapper_class = true
 end

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -153,6 +153,10 @@ module SimpleForm
   mattr_accessor :input_class
   @@input_class = nil
 
+  # Defines if an input wrapper class should be included or not
+  mattr_accessor :include_default_input_wrapper_class
+  @@include_default_input_wrapper_class = true
+
   ## WRAPPER CONFIGURATION
   # The default wrapper to be used by the FormBuilder.
   mattr_accessor :default_wrapper

--- a/lib/simple_form/inputs/collection_radio_buttons_input.rb
+++ b/lib/simple_form/inputs/collection_radio_buttons_input.rb
@@ -23,7 +23,7 @@ module SimpleForm
         options[:item_wrapper_tag] ||= options.fetch(:item_wrapper_tag, SimpleForm.item_wrapper_tag)
         options[:item_wrapper_class] = [
           item_wrapper_class, options[:item_wrapper_class], SimpleForm.item_wrapper_class
-        ].compact.presence
+        ].compact.presence if SimpleForm.include_default_input_wrapper_class
 
         options[:collection_wrapper_tag] ||= options.fetch(:collection_wrapper_tag, SimpleForm.collection_wrapper_tag)
         options[:collection_wrapper_class] = [

--- a/test/inputs/collection_check_boxes_input_test.rb
+++ b/test/inputs/collection_check_boxes_input_test.rb
@@ -232,4 +232,21 @@ class CollectionCheckBoxesInputTest < ActionView::TestCase
       assert_select 'label.checkbox.inline > input'
     end
   end
+
+  test 'input check boxes wrapper class are not included when set to falsey' do
+    swap SimpleForm, include_default_input_wrapper_class: false, boolean_style: :nested do
+      with_input_for @user, :gender, :check_boxes, collection: [:male, :female]
+
+      assert_no_select 'label.checkbox'
+    end
+  end
+
+  test 'input check boxes custom wrapper class is included when include input wrapper class is falsey' do
+    swap SimpleForm, include_default_input_wrapper_class: false, boolean_style: :nested do
+      with_input_for @user, :gender, :check_boxes, collection: [:male, :female], item_wrapper_class: 'custom'
+
+      assert_no_select 'label.checkbox'
+      assert_select 'label.custom'
+    end
+  end
 end

--- a/test/inputs/collection_radio_buttons_input_test.rb
+++ b/test/inputs/collection_radio_buttons_input_test.rb
@@ -325,4 +325,21 @@ class CollectionRadioButtonsInputTest < ActionView::TestCase
       assert_select 'label.radio.inline > input'
     end
   end
+
+  test 'input radio wrapper class are not included when set to falsey' do
+    swap SimpleForm, include_default_input_wrapper_class: false, boolean_style: :nested do
+      with_input_for @user, :gender, :radio_buttons, collection: [:male, :female]
+
+      assert_no_select 'label.radio'
+    end
+  end
+
+  test 'input check boxes custom wrapper class is included when include input wrapper class is falsey' do
+    swap SimpleForm, include_default_input_wrapper_class: false, boolean_style: :nested do
+      with_input_for @user, :gender, :radio_buttons, collection: [:male, :female], item_wrapper_class: 'custom'
+
+      assert_no_select 'label.radio'
+      assert_select 'label.custom'
+    end
+  end
 end


### PR DESCRIPTION
There could be faulty behavior when setting checkbox or radio class to the input wrapper, as in Bootstrap 3. To fix this I've added a new config as suggested in #930.
