### PR TITLE
Fix wrong HTML pattern regular expressions

### DIFF
--- a/lib/simple_form/components/pattern.rb
+++ b/lib/simple_form/components/pattern.rb
@@ -13,9 +13,16 @@ module SimpleForm
         pattern = options[:pattern]
         if pattern.is_a?(String)
           pattern
-        elsif (pattern_validator = find_pattern_validator) && (with = pattern_validator.options[:with])
-          evaluate_format_validator_option(with).source
+        elsif pattern_validator = find_pattern_validator and
+              with = pattern_validator.options[:with]
+        then
+          source = evaluate_format_validator_option(with).source
+          convert_regexp_from_ruby_to_ecma source
         end
+      end
+
+      def convert_regexp_from_ruby_to_ecma(source)
+        source.sub('\\A' , '^').sub('\\Z' , '$').sub('\\z' , '$')
       end
 
       def find_pattern_validator

--- a/test/form_builder/input_field_test.rb
+++ b/test/form_builder/input_field_test.rb
@@ -69,14 +69,14 @@ class InputFieldTest < ActionView::TestCase
 
   test 'builder input_field should use i18n to translate placeholder text' do
     store_translations(:en, simple_form: { placeholders: { user: {
-      name: 'Name goes here'
+      name: 'NameGoesHere'
     } } }) do
 
       with_concat_form_for(@user) do |f|
         f.input_field :name
       end
 
-      assert_select 'input.string[placeholder=Name goes here]'
+      assert_select 'input.string[placeholder=NameGoesHere]'
     end
   end
 
@@ -93,7 +93,7 @@ class InputFieldTest < ActionView::TestCase
       f.input_field :country, as: :string
     end
 
-    assert_select 'input[pattern="\w+"]'
+    assert_select 'input[pattern="^\w+$"]'
   end
 
   test 'builder input_field should use readonly component' do

--- a/test/inputs/string_input_test.rb
+++ b/test/inputs/string_input_test.rb
@@ -65,23 +65,23 @@ class StringInputTest < ActionView::TestCase
 
   test 'input should not infer pattern from attributes by default' do
     with_input_for @other_validating_user, :country, :string
-    assert_no_select 'input[pattern="\w+"]'
+    assert_no_select 'input[pattern="^\w+$"]'
   end
 
   test 'input should infer pattern from attributes' do
     with_input_for @other_validating_user, :country, :string, pattern: true
-    assert_select 'input[pattern="\w+"]'
+    assert_select 'input[pattern="^\w+$"]'
   end
 
   test 'input should infer pattern from attributes using proc' do
     with_input_for @other_validating_user, :name, :string, pattern: true
-    assert_select 'input[pattern="\w+"]'
+    assert_select 'input[pattern="^\w+$"]'
   end
 
   test 'input should not infer pattern from attributes if root default is false' do
     swap_wrapper do
       with_input_for @other_validating_user, :country, :string
-      assert_no_select 'input[pattern="\w+"]'
+      assert_no_select 'input[pattern="^\w+$"]'
     end
   end
 

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -214,8 +214,8 @@ class OtherValidatingUser < User
     less_than_or_equal_to: Proc.new { |user| user.age + 100 },
     only_integer: true
 
-  validates_format_of :country, with: /\w+/
-  validates_format_of :name, with: Proc.new { /\w+/ }
+  validates_format_of :country, with: /\A\w+\z/
+  validates_format_of :name, with: Proc.new { /\A\w+\Z/ }
   validates_format_of :description, without: /\d+/
 end
 


### PR DESCRIPTION
Transform the ruby REs from rails validations to REs that conform more
with the ECMA-262 standard, escpecially anchoring with ^ and $ instead
of \A and \z, \Z. Otherwise they won't be understood by browsers
implementing the HTML5 specs.
