### PR TITLE
Add check_box/boolean attribute example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ the wrapper as well:
   <%= f.input :date_of_birth, as: :date, start_year: Date.today.year - 90,
                               end_year: Date.today.year - 12, discard_day: true,
                               order: [:month, :year] %>
+  <%= f.input :accepts, as: :boolean, checked_value: true, unchecked_value: false %>
   <%= f.button :submit %>
 <% end %>
 ```


### PR DESCRIPTION
The ability to set checked and unchecked values on check_boxes (#643)
is really hard to find (mapping boolean<->check_box only makes it worse).

It seems well worth mentioning it inside the README.
