### PR TITLE
Fix Simple Form Foundation generator to use correct class with error

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form_foundation.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_foundation.rb
@@ -8,7 +8,7 @@ SimpleForm.setup do |config|
     b.optional :min_max
     b.optional :readonly
     b.use :label_input
-    b.use :error, wrap_with: { tag: :small }
+    b.use :error, wrap_with: { tag: :small, class: :error }
 
     # Uncomment the following line to enable hints. The line is commented out by default since Foundation
     # does't provide styles for hints. You will need to provide your own CSS styles for hints.


### PR DESCRIPTION
Right now, simple_form doesn't seem to _quite_ get the error class right for foundation. Specifically, the small tags don't get the "error" class added to them. Note the difference below: 

Before:
![before](https://f.cloud.github.com/assets/463175/2153597/b39fe6f0-9429-11e3-8f61-53d4834401d2.png)

After:
![after](https://f.cloud.github.com/assets/463175/2153598/b83f629e-9429-11e3-961a-52f081af2b6c.png)
