### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ By [Plataformatec](http://plataformatec.com.br/).
 [![Gem Version](https://fury-badge.herokuapp.com/rb/simple_form.png)](http://badge.fury.io/rb/simple_form)
 [![Build Status](https://api.travis-ci.org/plataformatec/simple_form.png?branch=master)](http://travis-ci.org/plataformatec/simple_form)
 [![Code Climate](https://codeclimate.com/github/plataformatec/simple_form.png)](https://codeclimate.com/github/plataformatec/simple_form)
+[![Inline docs](http://inch-pages.github.io/github/plataformatec/simple_form.png)](http://inch-pages.github.io/github/plataformatec/simple_form)
 
 Rails forms made easy.
 


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/plataformatec/simple_form.png)](http://inch-pages.github.io/github/plataformatec/simple_form)

It links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for SimpleForm is http://inch-pages.github.io/github/plataformatec/simple_form/

Inch Pages is still in it's infancy, but already used by projects like [Reek](https://github.com/troessner/reek) and [libnotify](https://github.com/splattael/libnotify).

What do you think? :man:
