### PR TITLE
Add EnumInput

### DIFF
--- a/lib/simple_form/inputs.rb
+++ b/lib/simple_form/inputs.rb
@@ -10,6 +10,7 @@ module SimpleForm
     autoload :CollectionRadioButtonsInput
     autoload :CollectionSelectInput
     autoload :DateTimeInput
+    autoload :EnumInput
     autoload :FileInput
     autoload :GroupedCollectionSelectInput
     autoload :HiddenInput

--- a/lib/simple_form/inputs/enum_input.rb
+++ b/lib/simple_form/inputs/enum_input.rb
@@ -1,0 +1,22 @@
+module SimpleForm
+  module Inputs
+    class EnumInput < CollectionSelectInput
+      def input
+        object = object_name.classify.constantize
+
+        collection = object.send(attribute_name.to_s.pluralize)
+        collection = map_collection(collection, attribute_name)
+
+        label_method, value_method = detect_collection_methods
+
+        @builder.collection_select(attribute_name, collection, value_method,
+                             label_method, input_options, input_html_options)
+      end
+
+      # Don't touch the collection by default
+      def map_collection(collection, attribute_name)
+        return collection
+      end
+    end
+  end
+end


### PR DESCRIPTION
This uses a little magic to infer how your enum works, but I think this will work in most cases.

The purpose of the `map_collection` method is to allow for custom mappings:

```
class EnumLocaleInput < SimpleForm::Inputs::EnumInput
  def map_collection(collection, attribute_name)
    collection.map { |slug, index| [I18n.t("enums.#{attribute_name}.#{slug}"), slug]}
  end
end
```

Very basic starting point. What do we think?
