### PR TITLE
Execute condition in the association context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 ### enhancements
+  * Execute the association `condition` in the object context. [@laurocaetano](https://github.com/laurocaetano)
   * Check if the given association responds to `order` before calling it. [@laurocaetano](https://github.com/laurocaetano)
   * Add Bootstrap 3 initializer template.
   * For radio or checkbox collection always use `:item_wrapper_tag` to wrap the content and add `label` when using `boolean_style` with `:nested` [@kassio](https://github.com/kassio) and [@erichkist](https://github.com/erichkist)

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -153,7 +153,7 @@ class User
       when :special_company
         Association.new(Company, association, :belongs_to, { conditions: { id: 1 } })
       when :extra_special_company
-        Association.new(Company, association, :belongs_to, { conditions: proc { { id: 1 } } })
+        Association.new(Company, association, :belongs_to, { conditions: proc { { id: self.id } } })
       when :pictures
         Association.new(Picture, association, :has_many, {})
     end


### PR DESCRIPTION
Execute the given `condition` in the association context. Alternative implementation for #872. 

Also extracted the `association` code responsible to build the attribute and fetch the conditions into private methods.

cc/ @rafaelfranca 

UPDATE:

The `condition` should be executed in the object context, because simple_form does not call the association object, instead it builds the relation using the class from the reflection. See: https://github.com/plataformatec/simple_form/blob/master/lib/simple_form/form_builder.rb#L189

Example

``` ruby
class User
  has_many :cars, conditions: -> { { user_id: self.id } }
end

# simple form will do:
Car.where(user_id: user.id)
```
