### PR TITLE
Warn users if Simple Form is not configured in the application

### DIFF
--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -36,6 +36,12 @@ to
 See https://github.com/plataformatec/simple_form/pull/997 for more information.
   WARN
 
+  @@configured = false
+
+  def self.configured? #:nodoc:
+    @@configured
+  end
+
   ## CONFIGURATION OPTIONS
 
   # Method used to tidy up errors.
@@ -235,6 +241,7 @@ See https://github.com/plataformatec/simple_form/pull/997 for more information.
   # Default way to setup SimpleForm. Run rails generate simple_form:install
   # to create a fresh initializer with all configuration values.
   def self.setup
+    @@configured = true
     yield self
   end
 end

--- a/lib/simple_form/railtie.rb
+++ b/lib/simple_form/railtie.rb
@@ -3,5 +3,12 @@ require 'rails/railtie'
 module SimpleForm
   class Railtie < Rails::Railtie
     config.eager_load_namespaces << SimpleForm
+
+    config.after_initialize do
+      unless SimpleForm.configured?
+        warn '[Simple Form] Simple Form is not configured in the application and will use the default values.' +
+          ' Use `rails generate simple_form:install` to generate the Simple Form configuration.'
+      end
+    end
   end
 end

--- a/test/simple_form_test.rb
+++ b/test/simple_form_test.rb
@@ -6,4 +6,12 @@ class SimpleFormTest < ActiveSupport::TestCase
       assert_equal SimpleForm, config
     end
   end
+
+  test 'setup block configure Simple Form' do
+    SimpleForm.setup do |config|
+      assert_equal SimpleForm, config
+    end
+
+    assert_equal true, SimpleForm.configured?
+  end
 end


### PR DESCRIPTION
If an users put Simple Form in the Gemfile and forget to configure it, it will use the default configuration included in the gem for backward compatibility.

This may lead some surprising behavior since the internal defaults are not equal to the documented default.

In the ideal world we would have both configuration matching but I prefer to keep this way to make easier to keep backward compatibility.

So, if `SimpleForm.setup` is not called in the application we will show a warning like this in console:

> [Simple Form] Simple Form was not configured in the application and will use the default values. Use `rails generate simple_form:install` to generate the Simple Form configuration.

Fixes #491
