### PR TITLE
Add documentation for `item_wrap_tag` used with `boolean_style` set to `:nested`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ end
 ```
 
 For check boxes and radio buttons you can remove the label changing `boolean_style` from default value `:nested` to `:inline`.
+Also, `item_wrap_tag` will not work when `boolean_style` is set to `:nested`.
 
 Example:
 


### PR DESCRIPTION
Closes #685 

Simple documentation to explain #685.
