### PR TITLE
Allows host app to configure what root scope simple_form uses for i18n.

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb
@@ -149,4 +149,8 @@ SimpleForm.setup do |config|
   # Defines if the default input wrapper class should be included in radio
   # collection wrappers.
   # config.include_default_input_wrapper_class = true
+
+  # Defines what i18n scope to use for simple_form.
+  # config.i18n_scope = 'simple_form'
+
 end

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -185,6 +185,9 @@ See https://github.com/plataformatec/simple_form/pull/997 for more information.
   @@default_wrapper = :default
   @@wrappers = {} #:nodoc:
 
+  mattr_accessor :i18n_scope
+  @@i18n_scope = 'simple_form'
+
   # Retrieves a given wrapper
   def self.wrapper(name)
     @@wrappers[name.to_s] or raise WrapperNotFound, "Couldn't find wrapper with name #{name}"

--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -182,7 +182,7 @@ module SimpleForm
         lookups << :"defaults.#{reflection_or_attribute_name}"
         lookups << default
 
-        I18n.t(lookups.shift, scope: :"simple_form.#{namespace}", default: lookups).presence
+        I18n.t(lookups.shift, scope: :"#{i18n_scope}.#{namespace}", default: lookups).presence
       end
 
       def merge_wrapper_options(options, wrapper_options)
@@ -196,6 +196,11 @@ module SimpleForm
           options
         end
       end
+
+      def i18n_scope
+        SimpleForm.i18n_scope
+      end
+
     end
   end
 end


### PR DESCRIPTION
In my organization we have multiple Rails applications sharing the same I18n assets. Each application is scoped, so we have an `apps.foo.*` scope and an `apps.bar.*` scope.

It would be nice if we could make simple_form conform to this scope and avoid mixing up keys that are tied to a particular application.

This pull request attempts to do that.
