### PR TITLE
Allow overriding `as: :radio_buttons` I18n options

### DIFF
--- a/lib/simple_form/inputs/collection_input.rb
+++ b/lib/simple_form/inputs/collection_input.rb
@@ -33,7 +33,9 @@ module SimpleForm
 
       def collection
         @collection ||= begin
-          collection = options.delete(:collection) || self.class.boolean_collection
+          collection = options.delete(:collection) ||
+                       boolean_collection_for(object_name, attribute_name) ||
+                       self.class.boolean_collection
           collection.respond_to?(:call) ? collection.call : collection.to_a
         end
       end
@@ -95,6 +97,18 @@ module SimpleForm
         (collection_classes & [
           String, Integer, Fixnum, Bignum, Float, NilClass, Symbol, TrueClass, FalseClass
         ]).any?
+      end
+
+      def boolean_collection_for(namespace, attribute)
+        overridden_booleans = translate(:options) || {}
+
+        translation_for_true = overridden_booleans[:true]
+        translation_for_false = overridden_booleans[:false]
+
+        if translation_for_true && translation_for_false
+          [ [translation_for_true, true],
+            [translation_for_false, false] ]
+        end
       end
 
       def translate_collection

--- a/test/inputs/collection_radio_buttons_input_test.rb
+++ b/test/inputs/collection_radio_buttons_input_test.rb
@@ -42,6 +42,26 @@ class CollectionRadioButtonsInputTest < ActionView::TestCase
     end
   end
 
+  test 'input as radio should allow overidding i18n for boolean labels' do
+    translations = {
+      simple_form: {
+        options: {
+          user: {
+            active: {
+              true: 'Sim!',
+              false: 'Não!'
+            }
+          }
+        }
+      }
+    }
+    store_translations(:en, translations) do
+      with_input_for @user, :active, :radio_buttons
+      assert_select 'label[for=user_active_true]', 'Sim!'
+      assert_select 'label[for=user_active_false]', 'Não!'
+    end
+  end
+
   test 'input radio should not include for attribute by default' do
     with_input_for @user, :gender, :radio_buttons, collection: [:male, :female]
     assert_select 'label'


### PR DESCRIPTION
In addition to overriding the default `yes` / `no` and `true` / `false`
options.

In this case, a `collection`-less radio button would do a lookup for
overridden `true` / `false`  I18n values

``` yml
simple_form:
  options:
    user:
      active:
        true: "Yes!"
        false: "No!"
```

This would allow for `f.input :active, as: :radio_buttons` to have a radio label
different from the default `Yes` / `No`
