### PR TITLE
minor documentation fix to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Rails helper, but change the builder to use the `SimpleForm::FormBuilder`.
 
 ```ruby
 form_for @user do |f|
-  f.simple_fields_for :posts do |posts_form|
+  simple_fields_for :posts do |posts_form|
     # Here you have all simple_form methods available
     posts_form.input :title
   end


### PR DESCRIPTION
you can't call `simple_fields_for` on the Rails form builder
