### PR TITLE
Add proper error_notification_class for Bootstrap 3

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
@@ -1,5 +1,6 @@
 # Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
+  config.error_notification_class = 'alert alert-danger'
   config.button_class = 'btn btn-default'
   config.boolean_label_class = nil
 


### PR DESCRIPTION
Commit a685ba45e06276ad90a4000cf12d82b333f7e6f4 rewrites some classes, but completely removes the config.error_notification_class in the Bootstrap override. Because of this, error notifications no longer show up as an alert.

I've added the override, using the correct Bootstrap 3 alert class `alert-danger`, which is the proper replacement voor `alert-error`.
