### PR TITLE
Update wrapper for :vertical_boolean

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
@@ -28,12 +28,13 @@ SimpleForm.setup do |config|
     end
   end
 
-  config.wrappers :vertical_boolean, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :vertical_boolean, tag: 'div', class: 'checkbox', error_class: 'has-error' do |b|
     b.use :html5
     b.use :placeholder
 
-    b.wrapper tag: 'div', class: 'checkbox' do |ba|
-      ba.use :label_input
+    b.wrapper tag: 'label' do |ba|
+      ba.use :input
+      ba.use :label_text
     end
 
     b.use :error, wrap_with: { tag: 'span', class: 'help-block' }


### PR DESCRIPTION
Before a checkbox was wrapped in a `form-group`, which shouldn't be there.
