### PR TITLE
Only output the wrapper if the block yields content

### DIFF
--- a/lib/simple_form/wrappers/many.rb
+++ b/lib/simple_form/wrappers/many.rb
@@ -50,6 +50,7 @@ module SimpleForm
 
       def wrap(input, options, content)
         return content if options[namespace] == false
+        return if defaults[:optional] && content.empty?
 
         tag = (namespace && options[:"#{namespace}_tag"]) || @defaults[:tag]
         return content unless tag

--- a/test/form_builder/hint_test.rb
+++ b/test/form_builder/hint_test.rb
@@ -141,4 +141,29 @@ class HintTest < ActionView::TestCase
       assert_select 'div.omg_hint', "can&#39;t be blank"
     end
   end
+
+  test 'optional hint displays when given' do
+    swap_wrapper :default, self.custom_wrapper_with_optional_div do
+      with_form_for @user, :name, hint: "can't be blank"
+      assert_select 'section.custom_wrapper div.no_output_wrapper p.omg_hint', "can&#39;t be blank"
+      assert_select 'p.omg_hint'
+    end
+  end
+
+  test 'optional hint displays empty wrapper when no hint given' do
+    swap_wrapper :default, self.custom_wrapper_with_optional_div do
+      with_form_for @user, :name
+      assert_select 'section.custom_wrapper div.no_output_wrapper'
+      assert_no_select 'p.omg_hint'
+    end
+  end
+
+  test 'optional hint displays no wrapper or hint when no hint and override is given' do
+    swap_wrapper :default, self.custom_wrapper_with_optional_div_and_override do
+      with_form_for @user, :name
+      assert_no_select 'section.custom_wrapper div.no_output_wrapper'
+      assert_no_select 'div.no_output_wrapper'
+      assert_no_select 'p.omg_hint'
+    end
+  end
 end

--- a/test/support/misc_helpers.rb
+++ b/test/support/misc_helpers.rb
@@ -68,6 +68,22 @@ module MiscHelpers
     end
   end
 
+  def custom_wrapper_with_optional_div
+    SimpleForm.build tag: :section, class: "custom_wrapper" do |b|
+      b.wrapper tag: :div, class: 'no_output_wrapper' do |ba|
+        ba.optional :hint, wrap_with: { tag: :p, class: 'omg_hint' }
+      end
+    end
+  end
+
+  def custom_wrapper_with_optional_div_and_override
+    SimpleForm.build tag: :section, class: "custom_wrapper" do |b|
+      b.wrapper tag: :div, class: 'no_output_wrapper', optional: true do |ba|
+        ba.optional :hint, wrap_with: { tag: :p, class: 'omg_hint' }
+      end
+    end
+  end
+
   def custom_wrapper_with_input_class
     SimpleForm.build tag: :div, class: "custom_wrapper" do |b|
       b.use :label


### PR DESCRIPTION
This change allows the wrappers to not output its HTML when when the block yields no content.

e.g. when defining an optional component :

``` ruby
ba.wrapper tag: :div, class: 'form-helper -message -hint' do |bb|
  bb.optional :hint, wrap_with: { tag: :p }
end
```

and that component is not used in a template :

``` erb
<%= form.input :name %>
```

Then the HTML output still contains the wrapper output :

``` html
<div class="form-helper -message -help"></div>
```

If this behaviour is not desired, then the output of the empty tags can be disabled via the `remove_empty` option.

``` ruby
ba.wrapper tag: :div, class: 'form-helper -message -hint', remove_empty: true do |bb|
  bb.optional :hint, wrap_with: { tag: :p }
end
```

The above config will not output any wrapper HTML.
