### PR TITLE
Support collection translations with lambdas for collection input

### DIFF
--- a/lib/simple_form/inputs/collection_input.rb
+++ b/lib/simple_form/inputs/collection_input.rb
@@ -101,9 +101,13 @@ module SimpleForm
             html_key = "#{key}_html".to_sym
 
             if translated_collection[html_key]
-              [translated_collection[html_key].html_safe || key, key.to_s]
+              translated = translated_collection[html_key]
+              translated = translated.call(html_key, options)  if translated.respond_to?(:call)
+              [translated.html_safe || key, key.to_s]
             else
-              [translated_collection[key] || key, key.to_s]
+              translated = translated_collection[key]
+              translated = translated.call(key, options)  if translated.respond_to?(:call)
+              [translated || key, key.to_s]
             end
           end
           true

--- a/test/inputs/collection_select_input_test.rb
+++ b/test/inputs/collection_select_input_test.rb
@@ -21,6 +21,14 @@ class CollectionSelectInputTest < ActionView::TestCase
     end
   end
 
+  test 'input as select uses i18n to translate select boolean options stored as lambdas' do
+    store_translations(:en, simple_form: { yes: -> (*) { 'Sim' }, no: -> (*) { 'Não' }}) do
+      with_input_for @user, :active, :select
+      assert_select 'select option[value=true]', 'Sim'
+      assert_select 'select option[value=false]', 'Não'
+    end
+  end
+
   test 'input allows overriding collection for select types' do
     with_input_for @user, :name, :select, collection: ['Jose', 'Carlos']
     assert_select 'select.select#user_name'


### PR DESCRIPTION
This allows to use dynamically generated translations.

It's pretty rarely needed thing, I think.

For example, I use this to DRY in translations (ability names was translated before):

``` ruby
{ ru: {
    simple_form: {
      options: {
        rank: {
          abilities: Hash[
            ABILITIES.map do |ability|
              [ability.to_sym, -> (*) { I18n.t(ability, scope: :abilities) }]
            end
          ]
}, }, }, }, }
```

Also, I'm currently passing translated key and input option to Proc in translations, but not sure, should it be ever passed. Can't imagine use cases, just mimics rails validators in behavior (rails passes attribute name and validator arguments to translation). So, further discussion is required.
