### PR TITLE
Fixing deprecation warning for nil columns in Rails 4.2.beta1

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -542,7 +542,7 @@ module SimpleForm
     end
 
     def find_attribute_column(attribute_name)
-      if @object.respond_to?(:column_for_attribute)
+      if @object.respond_to?(:column_for_attribute) && @object.has_attribute?(attribute_name)
         @object.column_for_attribute(attribute_name)
       end
     end

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -130,6 +130,16 @@ class User
     Column.new(attribute, column_type, limit)
   end
 
+  def has_attribute?(attribute)
+    case attribute.to_sym
+      when :name, :status, :password, :description, :age,
+        :credit_limit, :active, :born_at, :delivery_time,
+        :created_at, :updated_at, :lock_version, :home_picture,
+        :amount, :attempts, :action, :credit_card, :uuid then true
+      else false
+    end
+  end
+
   def self.human_attribute_name(attribute, options = {})
     case attribute
       when 'name'


### PR DESCRIPTION
This is an alternative solution for outstanding pull request #1094 

The underlying issue is that simple_form calls `column_for_attribute` on non-attribute inputs, for instance, password on a devise model. This results in a deprecation message from rails. The fix uses `has_attribute?`
to ensure we don't call `column_for_attribute` improperly.
