### PR TITLE
Boolean Fields in Horizontal Forms Firefox

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
@@ -87,7 +87,7 @@ SimpleForm.setup do |config|
 
     b.wrapper tag: 'div', class: 'col-sm-offset-3 col-sm-9' do |wr|
       wr.wrapper tag: 'div', class: 'checkbox' do |ba|
-        ba.use :label_input, class: 'col-sm-9'
+        ba.use :label_input
       end
 
       wr.use :error, wrap_with: { tag: 'span', class: 'help-block' }


### PR DESCRIPTION
Those fields are rendering incorrectly - showing label and then checkbox. This is due to nested ‘col-sm-9’ class on input tag.

![boolean_field_not_correct](https://cloud.githubusercontent.com/assets/1983566/5229802/304c97e4-771d-11e4-97bf-298eac1060c9.png)
