### PR TITLE
Fix the key of options example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,7 @@ And **Simple Form** will try a lookup like this in your locale file, to find the
 en:
   simple_form:
     options:
-      user:
+      users:
         gender:
           male: 'Male'
           female: 'Female'


### PR DESCRIPTION
The key of options with the name model on README need to be on plural.
