### PR TITLE
fix label on dates if HTML5 compatibility is explicitly enbled

### DIFF
--- a/lib/simple_form/inputs/date_time_input.rb
+++ b/lib/simple_form/inputs/date_time_input.rb
@@ -14,16 +14,20 @@ module SimpleForm
       private
 
       def label_target
-        position = case input_type
-        when :date, :datetime
-          date_order = input_options[:order] || I18n.t('date.order')
-          date_order.first.to_sym
+        if use_html5_inputs?
+          attribute_name
         else
-          :hour
-        end
+          position = case input_type
+          when :date, :datetime
+            date_order = input_options[:order] || I18n.t('date.order')
+            date_order.first.to_sym
+          else
+            :hour
+          end
 
-        position = ActionView::Helpers::DateTimeSelector::POSITION[position]
-        "#{attribute_name}_#{position}i"
+          position = ActionView::Helpers::DateTimeSelector::POSITION[position]
+          "#{attribute_name}_#{position}i"
+        end
       end
 
       def use_html5_inputs?

--- a/test/inputs/datetime_input_test.rb
+++ b/test/inputs/datetime_input_test.rb
@@ -169,4 +169,9 @@ class DateTimeInputWithoutHtml5Test < ActionView::TestCase
     with_input_for :project, :created_at, :time, html5: false
     assert_select 'label[for=project_created_at_4i]'
   end
+
+  test 'label points to attribute_name if HTML5 compatibility is explicitly enbled' do
+    with_input_for :project, :created_at, :date, html5: true
+    assert_select 'label[for=project_created_at]'
+  end
 end


### PR DESCRIPTION
When using HTML5 on dates, the form id no longer uses the position suffix but the label still did
