### PR TITLE
Added RichTextAreaInput for ActionText

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -26,6 +26,7 @@ module SimpleForm
     map_type :range,                                               to: SimpleForm::Inputs::RangeInput
     map_type :check_boxes,                                         to: SimpleForm::Inputs::CollectionCheckBoxesInput
     map_type :radio_buttons,                                       to: SimpleForm::Inputs::CollectionRadioButtonsInput
+    map_type :rich_text_area,                                      to: SimpleForm::Inputs::RichTextAreaInput
     map_type :select,                                              to: SimpleForm::Inputs::CollectionSelectInput
     map_type :grouped_select,                                      to: SimpleForm::Inputs::GroupedCollectionSelectInput
     map_type :date, :time, :datetime,                              to: SimpleForm::Inputs::DateTimeInput

--- a/lib/simple_form/inputs.rb
+++ b/lib/simple_form/inputs.rb
@@ -19,6 +19,7 @@ module SimpleForm
     autoload :PasswordInput
     autoload :PriorityInput
     autoload :RangeInput
+    autoload :RichTextAreaInput
     autoload :StringInput
     autoload :TextInput
   end

--- a/lib/simple_form/inputs/rich_text_area_input.rb
+++ b/lib/simple_form/inputs/rich_text_area_input.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module SimpleForm
+  module Inputs
+    class RichTextAreaInput < Base
+      def input(wrapper_options = nil)
+        merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
+
+        @builder.rich_text_area(attribute_name, merged_input_options)
+      end
+    end
+  end
+end

--- a/test/inputs/rich_text_area_input_test.rb
+++ b/test/inputs/rich_text_area_input_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+# encoding: UTF-8
+require 'test_helper'
+
+class RichTextAreaInputTest < ActionView::TestCase
+  test 'input generates a text area for text attributes' do
+    with_input_for @user, :description, :text
+    assert_select 'textarea.text#user_description'
+  end
+
+  test 'input generates a text area for text attributes that accept placeholder' do
+    with_input_for @user, :description, :text, placeholder: 'Put in some text'
+    assert_select 'textarea.text[placeholder="Put in some text"]'
+  end
+end


### PR DESCRIPTION
For #1638 I've added the appropriate input. 

I've also added a test that passes, but I'm not familiar enough with the rich_text_area in Rails to know what else I should be testing for: feedback appreciated!

I've tested this on a project in development and it seems to work nicely, but I haven't tried adding any optional attributes, so might be worth exploring