### PR TITLE
Allow additional form classes

### DIFF
--- a/lib/simple_form/action_view_extensions/form_helper.rb
+++ b/lib/simple_form/action_view_extensions/form_helper.rb
@@ -17,11 +17,14 @@ module SimpleForm
         unless options[:html].key?(:novalidate)
           options[:html][:novalidate] = !SimpleForm.browser_validations
         end
+
         if options[:html].key?(:class)
           options[:html][:class] = [SimpleForm.form_class, options[:html][:class]].compact
         else
           options[:html][:class] = [SimpleForm.form_class, SimpleForm.default_form_class, simple_form_css_class(record, options)].compact
         end
+
+        options[:html][:class] += Array.wrap(options.dig(:html, :classes)).compact
 
         with_simple_form_field_error_proc do
           form_for(record, options, &block)

--- a/test/action_view_extensions/form_helper_test.rb
+++ b/test/action_view_extensions/form_helper_test.rb
@@ -33,6 +33,18 @@ class FormHelperTest < ActionView::TestCase
     end
   end
 
+  test 'SimpleForm allows additional form classes' do
+    with_concat_form_for :user, html: { classes: ['my_class', 'another_class'] }
+    assert_select 'form.my_class.another_class'
+  end
+
+  test 'SimpleForm allows additional form classes to default form class' do
+    swap SimpleForm, default_form_class: "my_custom_class" do
+      with_concat_form_for :user, html: { classes: ['my_class', 'another_class'] }
+      assert_select 'form.my_custom_class.another_class'
+    end
+  end
+
   test 'SimpleForm uses default browser validations by default' do
     with_concat_form_for(:user)
     assert_no_select 'form[novalidate]'


### PR DESCRIPTION
This lets you add one or more classes to the form without replacing the default classes. Particularly useful for libraries that require you to add a class to the form, such as [Dropzone.js](https://www.dropzonejs.com/#installation).

```erb
<%= simple_form_for(@user, html: { classes: 'dropzone' }) do |f| %>
   ...
<% end %>
```

⬇️

```html
<form class="simple_form new_user dropzone" ...>
```