### PR TITLE
Remove instruction to use form-inline class

### DIFF
--- a/lib/generators/simple_form/templates/README
+++ b/lib/generators/simple_form/templates/README
@@ -3,9 +3,8 @@
   Be sure to have a copy of the Bootstrap stylesheet available on your
   application, you can get it on http://getbootstrap.com/.
 
-  Inside your views, use the 'simple_form_for' with the Bootstrap form
-  class, '.form-inline', as the following:
+  For usage examples and documentation, see:
 
-    = simple_form_for(@user, html: { class: 'form-inline' }) do |form|
+    http://simple-form-bootstrap.plataformatec.com.br/
 
 ===============================================================================


### PR DESCRIPTION
This PR changes the console output that is shown when the installer is invoked with the --bootstrap option
```
rails generate simple_form:install --bootstrap
```

The previous instruction was a bit confusing, as form-inline is only one of the many possible classes that can be used. It’s also (probably) not the one that is most often used, so mentioning it in the installation output implies that it’s more significant than it actually is.

The sentence was also imperative:

	Inside your views, use the 'simple_form_for' with the Bootstrap form class, ‘.form-inline’

BEFORE
```
===============================================================================

  Be sure to have a copy of the Bootstrap stylesheet available on your
  application, you can get it on http://getbootstrap.com/.

  Inside your views, use the 'simple_form_for' with the Bootstrap form
  class, '.form-inline', as the following:

    = simple_form_for(@user, html: { class: 'form-inline' }) do |form|

===============================================================================
```

AFTER
```
===============================================================================

  Be sure to have a copy of the Bootstrap stylesheet available on your
  application, you can get it on http://getbootstrap.com/.

  For usage examples and documentation, see:

    http://simple-form-bootstrap.plataformatec.com.br/

===============================================================================
```

Closes #1687 