### PR TITLE
fix build_hidden_field_for_checkbox not returning ActiveSupport::SafeBuffer instance.

### DIFF
--- a/lib/simple_form/inputs/boolean_input.rb
+++ b/lib/simple_form/inputs/boolean_input.rb
@@ -60,7 +60,7 @@ module SimpleForm
       # we need the hidden field to be *outside* the label (otherwise it
       # generates invalid html - html5 only).
       def build_hidden_field_for_checkbox
-        return "" if !include_hidden? || !unchecked_value
+        return "".html_safe if !include_hidden? || !unchecked_value
         options = { value: unchecked_value, id: nil, disabled: input_html_options[:disabled] }
         options[:name] = input_html_options[:name] if input_html_options.key?(:name)
         options[:form] = input_html_options[:form] if input_html_options.key?(:form)


### PR DESCRIPTION
Returning a normal string here would result in raw html displaying on the final page, instead of the actual form. This fix ensure a ActiveSupport::SafeBuffer