### PR TITLE
Add symbol support to the collection option from the association builder

### DIFF
--- a/lib/simple_form/inputs/collection_input.rb
+++ b/lib/simple_form/inputs/collection_input.rb
@@ -36,6 +36,7 @@ module SimpleForm
       def collection
         @collection ||= begin
           collection = options.delete(:collection) || self.class.boolean_collection
+          collection = reflection.klass.send(collection) if collection.is_a?(Symbol)
           collection.respond_to?(:call) ? collection.call : collection.to_a
         end
       end

--- a/test/form_builder/association_test.rb
+++ b/test/form_builder/association_test.rb
@@ -40,6 +40,12 @@ class AssociationTest < ActionView::TestCase
     assert_equal 3, calls
   end
 
+  test 'builder association accepts symbols to use as scopes' do
+    simple_form_for @user do |f|
+      f.association :company, collection: :all
+    end
+  end
+
   test 'builder association marks input as required based on both association and attribute' do
     swap SimpleForm, required_by_default: false do
       with_association_for @validating_user, :company, collection: []


### PR DESCRIPTION
### Purpose

This change allows the association builder to use symbols as arguments for its collection option. Which will then send them to the class implied from the reflection.

E.g.:
```ruby
f.association :company, collection: :active
```
Which would essentially result in the same as:
```ruby
f.association :company, collection: Company.active
```

### Changes
Previously, passing a symbol to the collection key would result in an undefined method `#to_a` for the given symbol. This includes a check for the collection key being a symbol, which then sends the given symbol to the reflection klass, which, returning an object that responds to `#to_a` fits in easily with the current code.

### Reasoning
Passing the collection argument for the association builder in the view requires a reference to the class. The proposed change allows for a more loose relation between the view and your class names, allowing for more reusability.

### Known issues
- The current implementation doesn't allow for class methods with arguments. But should work nicely for simple scopes.

### Notes
This is my first contribution and I have but passing knowledge of the code base. I'd appreciate an honest review and feedback and would love to dig into it more if needed. Thanks!
