### PR TITLE
Remove unused methods

### DIFF
--- a/lib/simple_form/components/maxlength.rb
+++ b/lib/simple_form/components/maxlength.rb
@@ -24,10 +24,6 @@ module SimpleForm
         find_validator(:length)
       end
 
-      def has_tokenizer?(length_validator)
-        length_validator.options[:tokenizer]
-      end
-
       def maximum_length_value_from(length_validator)
         if length_validator
           length_validator.options[:is] || length_validator.options[:maximum]

--- a/lib/simple_form/components/minlength.rb
+++ b/lib/simple_form/components/minlength.rb
@@ -24,10 +24,6 @@ module SimpleForm
         find_validator(:length)
       end
 
-      def has_tokenizer?(length_validator)
-        length_validator.options[:tokenizer]
-      end
-
       def minimum_length_value_from(length_validator)
         if length_validator
           length_validator.options[:is] || length_validator.options[:minimum]


### PR DESCRIPTION
Validation with a tokenizer was only supported for versions of Rails
less than 5. As noted [here](https://github.com/heartcombo/simple_form/blob/v3.5.1/lib/simple_form/components/maxlength.rb#L31-L32)

When [Rails 4 support was dropped](https://github.com/heartcombo/simple_form/commit/ffc13c9925da957c274c1f090f7fc80b65fda307), the use of the `has_tokenizer?` method is
no longer used anywhere in the project. These changes remove the unused
methods.