### PR TITLE
I18nCache: Fix overtaken class var RuntimeError in Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
 gemfile:
   - gemfiles/Gemfile.rails-5-0-stable
   - gemfiles/Gemfile.rails-5-1-stable
@@ -19,6 +20,12 @@ matrix:
     - rvm: 2.7
       gemfile: gemfiles/Gemfile.rails-5-1-stable
     - rvm: 2.7
+      gemfile: gemfiles/Gemfile.rails-5-2-stable
+    - rvm: 3.0
+      gemfile: gemfiles/Gemfile.rails-5-0-stable
+    - rvm: 3.0
+      gemfile: gemfiles/Gemfile.rails-5-1-stable
+    - rvm: 3.0
       gemfile: gemfiles/Gemfile.rails-5-2-stable
 before_install:
   - gem update --system

--- a/lib/simple_form/i18n_cache.rb
+++ b/lib/simple_form/i18n_cache.rb
@@ -5,19 +5,29 @@ module SimpleForm
   # caching facility to speed up form construction.
   module I18nCache
     def i18n_cache(key)
-      get_i18n_cache(key)[I18n.locale] ||= yield.freeze
-    end
-
-    def get_i18n_cache(key)
-      if class_variable_defined?(:"@@#{key}")
-        class_variable_get(:"@@#{key}")
-      else
-        reset_i18n_cache(key)
-      end
+      store = I18nCacheStore.instance
+      store[key] ||= {}
+      store[key][I18n.locale] ||= yield.freeze
     end
 
     def reset_i18n_cache(key)
-      class_variable_set(:"@@#{key}", {})
+      I18nCacheStore.instance[key] = {}
+    end
+  end
+
+  class I18nCacheStore
+    include Singleton
+
+    def initialize
+      @store ||= {}
+    end
+
+    def [](key)
+      @store[key]
+    end
+
+    def []=(key, value)
+      @store[key] = value
     end
   end
 end


### PR DESCRIPTION
This fixes errors like the one below in Ruby 3.0 by replacing the class variables with a singleton for caching the translations.

        RuntimeError: class variable @@translate_required_html of SimpleForm::Inputs::StringInput is overtaken by SimpleForm::Inputs::Base
          .../simple_form/lib/simple_form/i18n_cache.rb:13:in `class_variable_get'
          .../simple_form/lib/simple_form/i18n_cache.rb:13:in `get_i18n_cache'
          .../simple_form/lib/simple_form/i18n_cache.rb:8:in `i18n_cache'
          .../simple_form/lib/simple_form/components/labels.rb:9:in `translate_required_html'
          .../simple_form/lib/simple_form/components/labels.rb:71:in `required_label_text'
          .../simple_form/lib/simple_form/components/labels.rb:43:in `label_text'
          .../simple_form/lib/simple_form/components/labels.rb:35:in `label'

Related issue: https://github.com/heartcombo/simple_form/issues/1720