### PR TITLE
Avoid a lot of NameError exceptions

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -674,7 +674,7 @@ module SimpleForm
       return if SimpleForm.inputs_discovery == false && at == Object
 
       begin
-        at.const_get(mapping) if at.constants.include?(mapping.to_sym)
+        at.const_get(mapping) if at.const_defined?(mapping)
       rescue NameError => e
         raise if e.message !~ /#{mapping}$/
       end

--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -674,7 +674,7 @@ module SimpleForm
       return if SimpleForm.inputs_discovery == false && at == Object
 
       begin
-        at.const_get(mapping)
+        at.const_get(mapping) if at.constants.include?(mapping.to_sym)
       rescue NameError => e
         raise if e.message !~ /#{mapping}$/
       end


### PR DESCRIPTION
### Purpose

Greatly improves rendering time by avoiding the generation of `NameError` exception

### Context

Rendering a view with 966 inputs (ok I admit it's a mess) allowed me to see that this portion of code is not optimized at all.

I used https://github.com/tmm1/stackprof on my view to understand via the flamegraph that ~ 70% of the time is dedicated to handle `NameError` exceptions.

### Changes

Instead of trying to obtain a constant directly, it is verified that it exists first.

### Results

#### development environment :
Flamegraph  :arrow_left: before and after :arrow_right: fix :
<img alt="Flamegraph before fix" src="https://user-images.githubusercontent.com/3259059/106168314-699bca80-618e-11eb-9df6-116b1729e17a.png" width="400px"/> <img alt="Flamegraph after fix" src="https://user-images.githubusercontent.com/3259059/106168321-6b658e00-618e-11eb-9e6c-19ee4813e802.png" width="400px"/>
As you can see before the fix, a lot of time was spent in the `SimpleForm::FormBuilder#attempt_maping`.

In the development environment the view rendering speed up is ~=> X 5.0

#### production environment : _( edit: not reproduced afterwards )_

The same view goes from :
`Completed 200 OK in 2658ms (Views: 2637.2ms | ActiveRecord: 12.0ms | Allocations: 1240207)`
to
`Completed 200 OK in 1503ms (Views: 1482.9ms | ActiveRecord: 13.3ms | Allocations: 1244907)`

In the production environment the view rendering speed up is ~=> (2637 / 1482) = X 1.78 

And many thanks for your great work 😙