### PR TITLE
Replace "overriden" with "overridden"

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb
@@ -112,7 +112,7 @@ SimpleForm.setup do |config|
   # You can define the class to use on all labels. Default is nil.
   # config.label_class = nil
 
-  # You can define the default class to be used on forms. Can be overriden
+  # You can define the default class to be used on forms. Can be overridden
   # with `html: { :class }`. Defaulting to none.
   # config.default_form_class = nil
 

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -114,7 +114,7 @@ See http://blog.plataformatec.com.br/2019/09/incorrect-access-control-in-simple-
   mattr_reader :form_class
   @@form_class = :simple_form
 
-  # You can define the default class to be used on all forms. Can be overriden
+  # You can define the default class to be used on all forms. Can be overridden
   # with `html: { :class }`. Defaults to none.
   mattr_accessor :default_form_class
   @@default_form_class = nil


### PR DESCRIPTION
Fixes typos in some comments.