### PR TITLE
Multiple Wrapper Mappings

### DIFF
--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -139,11 +139,21 @@ See http://blog.plataformatec.com.br/2019/09/incorrect-access-control-in-simple-
 
   # Custom wrappers for input types. This should be a hash containing an input
   # type as key and the wrapper that will be used for all inputs with specified type.
-  # e.g { string: :string_wrapper, boolean: :boolean_wrapper }
+  # e.g config.wrapper_mappings = { string: :string_wrapper, boolean: :boolean_wrapper }
   # You can also set a wrapper mapping per form basis.
   # e.g simple_form_for(@foo, wrapper_mappings: { check_boxes: :bootstrap_checkbox })
-  mattr_accessor :wrapper_mappings
-  @@wrapper_mappings = nil
+  # If you wish to create another set of wrappers you can do so
+  # config.wrapper_mappings[:inline] = { string: :inline_string }
+  # Which will allow referencing a set of wrappers with the set key
+  # e.g simple_form_for(@foo, wrapper_mappings: :custom)
+
+  def self.wrapper_mappings
+    @@wrapper_mappings ||= {}
+  end
+
+  def self.wrapper_mappings=(opts)
+    wrapper_mappings[:default] = opts
+  end
 
   # Namespaces where SimpleForm should look for custom input classes that override
   # default inputs. Namespaces are given as string to allow lazy loading inputs.

--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -636,11 +636,10 @@ module SimpleForm
     # 1) It tries to find a wrapper for the current form
     # 2) If not, it tries to find a config
     def find_wrapper_mapping(input_type)
-      if options[:wrapper_mappings] && options[:wrapper_mappings][input_type]
-        options[:wrapper_mappings][input_type]
-      else
-        SimpleForm.wrapper_mappings && SimpleForm.wrapper_mappings[input_type]
-      end
+      mapping = options[:wrapper_mappings]
+      mapping.is_a?(Hash) && mapping[input_type] ||
+        SimpleForm.wrapper_mappings.fetch(mapping, {}).try(:[], input_type) ||
+          SimpleForm.wrapper_mappings.fetch(:default, {}).try(:[], input_type)
     end
 
     def find_wrapper(input_type, options)

--- a/test/form_builder/wrapper_test.rb
+++ b/test/form_builder/wrapper_test.rb
@@ -245,6 +245,23 @@ class WrapperTest < ActionView::TestCase
     end
   end
 
+  test 'uses custom wrapper mapping for specified in config mapping' do
+    swap_wrapper :another do
+      swap SimpleForm, wrapper_mappings: { string: :not_found } do
+        begin
+          SimpleForm.wrapper_mappings[:custom] = { string: :another }
+          with_concat_form_for @user, wrapper_mappings: :custom do |f|
+            concat f.input :name
+          end
+          assert_select "section.custom_wrapper div.another_wrapper label"
+          assert_select "section.custom_wrapper div.another_wrapper input.string"
+        ensure
+          SimpleForm.wrapper_mappings.delete(:custom)
+        end
+      end
+    end
+  end
+
   test 'uses custom wrapper mapping per form basis' do
     swap_wrapper :another do
       with_concat_form_for @user, wrapper_mappings: { string: :another } do |f|


### PR DESCRIPTION
Allow usage of wrapper_mapping sets whilst maintaining backwards
compatible config as per issue/suggestion
https://github.com/heartcombo/simple_form/issues/1632