### PR TITLE
Add new rule for finding wrapper mappings

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -634,10 +634,13 @@ module SimpleForm
     # Attempts to find a wrapper mapping. It follows the following rules:
     #
     # 1) It tries to find a wrapper for the current form
-    # 2) If not, it tries to find a config
+    # 2) It tries to find a wrapper for the current wrapper(@wrapper)
+    # 3) If not, it tries to find a config
     def find_wrapper_mapping(input_type)
       if options[:wrapper_mappings] && options[:wrapper_mappings][input_type]
         options[:wrapper_mappings][input_type]
+      elsif @wrapper.options[:wrapper_mappings] && @wrapper.options[:wrapper_mappings][input_type]
+        @wrapper.options[:wrapper_mappings][input_type]
       else
         SimpleForm.wrapper_mappings && SimpleForm.wrapper_mappings[input_type]
       end

--- a/test/form_builder/wrapper_test.rb
+++ b/test/form_builder/wrapper_test.rb
@@ -256,6 +256,19 @@ class WrapperTest < ActionView::TestCase
     assert_select "section.custom_wrapper div.another_wrapper input.string"
   end
 
+  test 'uses wrapper with mappings when building form' do
+    swap_wrapper :default, custom_wrapper_with_wrapper_mappings({ string: :another }) do
+      swap_wrapper :another do
+        with_concat_form_for @user do |f|
+          concat f.input :name
+        end
+      end
+    end
+
+    assert_select "section.custom_wrapper div.another_wrapper label"
+    assert_select "section.custom_wrapper div.another_wrapper input.string"
+  end
+
   test 'simple_fields_form reuses custom wrapper mapping per form basis' do
     @user.company = Company.new(1, 'Empresa')
 

--- a/test/support/misc_helpers.rb
+++ b/test/support/misc_helpers.rb
@@ -69,6 +69,22 @@ module MiscHelpers
     end
   end
 
+  def custom_wrapper_with_wrapper_mappings(mappings=nil)
+    options = {tag: :section, class: "custom_wrapper", pattern: false}
+    options[:wrapper_mappings] =  mappings if mappings
+    SimpleForm.build options do |b|
+      b.use :pattern
+      b.wrapper :grid_wrapper, class: "grid" do |ba|
+        ba.use :label
+        ba.use :input
+      end
+      b.wrapper :error_wrapper, tag: :div, class: "error_wrapper" do |be|
+        be.use :error, wrap_with: { tag: :span, class: "omg_error" }
+      end
+      b.use :hint, wrap_with: { class: "omg_hint" }
+    end
+  end
+
   def custom_wrapper_with_wrapped_optional_component
     SimpleForm.build tag: :section, class: "custom_wrapper" do |b|
       b.wrapper tag: :div, class: 'no_output_wrapper' do |ba|


### PR DESCRIPTION
I want to specify different wrapper mappings for each wrapper of form. (#1757)
So, I added new rule for finding wrapper mappings to `FormBuilder#find_wrapper_mapping`.

Please adopt it if you like.