### PR TITLE
Support custom validation contexts in `required`

### DIFF
--- a/lib/simple_form/helpers/required.rb
+++ b/lib/simple_form/helpers/required.rb
@@ -19,7 +19,13 @@ module SimpleForm
       end
 
       def required_by_validators?
-        (attribute_validators + reflection_validators).any? { |v| v.kind == :presence && valid_validator?(v) }
+        (attribute_validators + reflection_validators).any? { |v| v.kind == :presence && valid_validator?(v) && required_by_validation_context?(v) }
+      end
+
+      def required_by_validation_context?(validator)
+        return true if options[:context].blank? || validator.options[:on].blank?
+
+        validator.options[:on] == options[:context]
       end
 
       def required_by_default?

--- a/lib/simple_form/helpers/validators.rb
+++ b/lib/simple_form/helpers/validators.rb
@@ -34,6 +34,8 @@ module SimpleForm
           !object.persisted?
         when :update
           object.persisted?
+        else
+          options[:context] == validator.options[:on]
         end
       end
 

--- a/test/inputs/required_test.rb
+++ b/test/inputs/required_test.rb
@@ -144,6 +144,34 @@ class RequiredTest < ActionView::TestCase
     assert_select 'input.optional#validating_user_phone_number'
   end
 
+  test 'builder input does not be required when validation is on custom context which is not active' do
+    with_form_for @validating_user, :home_picture
+    assert_no_select 'input.required'
+    assert_no_select 'input[required]'
+    assert_select 'input.optional#validating_user_home_picture'
+  end
+
+  test 'builder input is required when validation is on custom context which is active' do
+    with_form_for @validating_user, :home_picture, context: :with_picture
+    assert_select 'input.required'
+    assert_select 'input[required]'
+    assert_select 'input.required[required]#validating_user_home_picture'
+  end
+
+  test 'builder input is required when validation has no custom context, but another one is active' do
+    with_form_for @validating_user, :name, context: :with_picture
+    assert_select 'input.required'
+    assert_select 'input[required]'
+    assert_select 'input.required[required]#validating_user_name'
+  end
+
+  test 'builder input does not be required when validation has no custom context, but another one is active' do
+    with_form_for @validating_user, :attempts, context: :with_picture
+    assert_no_select 'input.required'
+    assert_no_select 'input[required]'
+    assert_select 'input.optional#validating_user_attempts'
+  end
+
   test 'builder input does not generate required html attribute when option is set to false when it is set to true in wrapper' do
     swap SimpleForm, browser_validations: true do
       swap_wrapper :default, self.custom_wrapper_with_required_input do

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -262,6 +262,7 @@ class ValidatingUser < User
   validates :company, presence: true
   validates :age, presence: true, if: proc { |user| user.name }
   validates :amount, presence: true, unless: proc { |user| user.age }
+  validates :home_picture, presence: true, on: :with_picture
 
   validates :action,            presence: true, on: :create
   validates :credit_limit,      presence: true, on: :save


### PR DESCRIPTION
This PR proposes to support custom validation contexts to determine whether a field is `required` or not.

## Current Behavior

Given the model:

```ruby
class User
  validates :name, presence: true
  validates :avatar, presence: true, on: :with_picture
end
```

The following currently renders both `name` and `avatar` as `required`:

```erb
<%= simple_form_for @user do |f| %>
  <%= f.input :name %>
  <%= f.input :avatar %>
<% end %>
```

This does not correspond to the behavior of `@user.save`, which does not require `avatar`.

## Proposed Solution

This PR proposes a new option `context` on inputs. Its value is used to determine whether the input is required or not.

The above example would only mark `name` as `required. The following example marks both `name` and `avatar` as `required`.

```erb
<%= simple_form_for @user do |f| %>
  <%= f.input :name %>
  <%= f.input :avatar, context: :with_picture %>
<% end %>
```

The logic is as follows:

| Validation context of `validates` in the model | `context` option of input | Required |
| ------------- | ------------- | ------- |
| `validates presence: true` | `context: :with_picture`  | required |
| `validates presence: true, on: :with_picture`  | none | optional |
| `validates presence: true, on: :with_picture`  | `context: :with_picture` | required |

With the current feature set of `simple_form`, it is already possible to define the `context` option for the whole form:

```erb
<%= simple_form_for @user, defaults: { context: :with_picture } do |f| %>
  <%= f.input :name %>
  <%= f.input :avatar %>
<% end %>
```

This would make working with validation contexts much easier, in my opinion 🙂

## Current Workaround

The `required` option on the input can be used already to control this behavior. However, determining whether there is a presence validator on the context requires extra code, and cannot be set on the whole form easily (cf. https://stackoverflow.com/a/14234720/1023963).
