### PR TITLE
Only call where if needed

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -497,7 +497,7 @@ module SimpleForm
           conditions = reflection.options[:conditions]
           conditions = object.instance_exec(&conditions) if conditions.respond_to?(:call)
 
-          relation = relation.where(conditions) if relation.respond_to?(:where)
+          relation = relation.where(conditions) if relation.respond_to?(:where) && conditions.present?
           relation = relation.order(order) if relation.respond_to?(:order)
         end
 


### PR DESCRIPTION
Calling `where` with a nil argument is not supported in [mongoid](https://github.com/mongodb/mongoid/blob/5c90efb00347e25d8b5ff0ce27d00ac8c906f0e2/lib/mongoid/criteria/queryable/selectable.rb#L795) and throws an error.

Calling `where` only if there are any conditions fixes this issue and seems to me a straightforward change.
The question is if there are cases where you want to call `where` with a nil argument?