### PR TITLE
Honor `include_hidden` on inline boolean inputs

### DIFF
--- a/lib/simple_form/inputs/boolean_input.rb
+++ b/lib/simple_form/inputs/boolean_input.rb
@@ -12,7 +12,11 @@ module SimpleForm
                 inline_label
             }
         else
-          build_check_box(unchecked_value, merged_input_options)
+          if include_hidden?
+            build_check_box(unchecked_value, merged_input_options)
+          else
+            build_check_box_without_hidden_field(merged_input_options)
+          end
         end
       end
 

--- a/test/inputs/boolean_input_test.rb
+++ b/test/inputs/boolean_input_test.rb
@@ -33,6 +33,11 @@ class BooleanInputTest < ActionView::TestCase
     assert_select 'input[type=hidden][value=off]'
   end
 
+  test 'input allows skipping hidden input when setting :include_hidden to false' do
+    with_input_for @user, :active, :boolean, include_hidden: false
+    assert_no_select "input[type=hidden][name='user[active]']"
+  end
+
   test 'input uses inline boolean style by default' do
     with_input_for @user, :active, :boolean
     assert_select 'input.boolean + label.boolean.optional'


### PR DESCRIPTION
On `nested`-style boolean inputs, it's possible to opt-out of the hidden input
generation by passing the `include_hidden: false` option.

However, for `inline` inputs, this still generates the hidden field, causing
an inconsistency between the two boolean styles, and a whole lot of late night confusion.

A workaround has been proposed in [a comment from 2016](https://github.com/heartcombo/simple_form/issues/1377#issuecomment-227616280),
which consists in passing `include_hidden` in the `input_html`. I think this is 
not ideal, as it causes inconsitencies between the APIs of the boolean styles.

This PR makes the inline checkboxes honor the `include_hidden` styles, making their API consistent.
