### PR TITLE
Resolves #1790 - use e.is_a? instead of e.message

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -676,7 +676,7 @@ module SimpleForm
       begin
         at.const_get(mapping)
       rescue NameError => e
-        raise if e.message !~ /#{mapping}$/
+        raise unless e.is_a? NameError
       end
     end
 


### PR DESCRIPTION
Switching to checking if the exception is a name error reduces the processing time for cases where a client application has extended how the exception processing works