### PR TITLE
Add missing documentation for ActionText

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,7 @@ Mapping         | Generated HTML Element               | Database Column Type
 `check_boxes`   | collection of `input[type=checkbox]` | `has_many`/`has_and_belongs_to_many` associations
 `country`       | `select` (countries as options)      | `string` with `name =~ /country/`
 `time_zone`     | `select` (timezones as options)      | `string` with `name =~ /time_zone/`
+`rich_text_area`| `trix-editor`                        | `has_rich_text` associations
 
 ## Custom inputs
 


### PR DESCRIPTION
Hi there!, first of all I wanna thank everyone for this great gem :rocket: . 

I was trying to use this gem with an input defined with `has_rich_text` but could not find any reference on how to do it. Found this issue #1638, and near the end of the discussion found some comments, with suggestions on how to use it. So I decided to add this missing documentation for future references.