### PR TITLE
Add default_builder configuration option

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb
@@ -173,4 +173,7 @@ SimpleForm.setup do |config|
   # Defines validation classes to the input_field. By default it's nil.
   # config.input_field_valid_class = 'is-valid'
   # config.input_field_error_class = 'is-invalid'
+
+  # Defines the default form builder when more customization is needed.
+  # config.default_builder = 'SimpleForm::OtherCSSFramework::FormBuilder'
 end

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -213,6 +213,9 @@ See http://blog.plataformatec.com.br/2019/09/incorrect-access-control-in-simple-
   mattr_accessor :input_field_valid_class
   @@input_field_valid_class = nil
 
+  mattr_accessor :default_builder
+  @@default_builder = 'SimpleForm::FormBuilder'
+
   # Retrieves a given wrapper
   def self.wrapper(name)
     @@wrappers[name.to_s] or raise WrapperNotFound, "Couldn't find wrapper with name #{name}"

--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -23,7 +23,7 @@ module SimpleForm
         if self.class < ActionView::Helpers::FormBuilder
           options[:builder] ||= self.class
         else
-          options[:builder] ||= SimpleForm::FormBuilder
+          options[:builder] ||= SimpleForm.default_builder.constantize
         end
         fields_for(*args, options, &block)
       end

--- a/lib/simple_form/action_view_extensions/form_helper.rb
+++ b/lib/simple_form/action_view_extensions/form_helper.rb
@@ -12,7 +12,7 @@ module SimpleForm
     module FormHelper
 
       def simple_form_for(record, options = {}, &block)
-        options[:builder] ||= SimpleForm::FormBuilder
+        options[:builder] ||= SimpleForm.default_builder.constantize
         options[:html] ||= {}
         unless options[:html].key?(:novalidate)
           options[:html][:novalidate] = !SimpleForm.browser_validations
@@ -30,7 +30,7 @@ module SimpleForm
 
       def simple_fields_for(record_name, record_object = nil, options = {}, &block)
         options, record_object = record_object, nil if record_object.is_a?(Hash) && record_object.extractable_options?
-        options[:builder] ||= SimpleForm::FormBuilder
+        options[:builder] ||= SimpleForm.default_builder.constantize
 
         with_simple_form_field_error_proc do
           fields_for(record_name, record_object, options, &block)


### PR DESCRIPTION
For some CSS frameworks the current Simple Form configuration options are not enough. In particular, the error notification may require [additional nesting](https://github.com/abevoelker/simple_form_tailwind_css/blob/master/lib/simple_form/tailwind/error_notification.rb). But also data attributes on some wrappers may be [required](https://react.carbondesignsystem.com/?path=/story/components-textinput--playground&args=invalid:true). By introducing the `default_builder` configuration option any framework should be able to be configured.

In the case of [simple_form_tailwind_css](https://github.com/abevoelker/simple_form_tailwind_css#usage) this would allow to use

```erb
<%= simple_form_for(@foo) do |f| %>
```

instead of

```erb
<%= simple_form_for(@foo, builder: SimpleForm::Tailwind::FormBuilder) do |f| %>
```

See also #1723.