### PR TITLE
Override lookup_action passing builder options

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -5,7 +5,7 @@ require 'simple_form/tags'
 
 module SimpleForm
   class FormBuilder < ActionView::Helpers::FormBuilder
-    attr_reader :template, :object_name, :object, :wrapper
+    attr_reader :template, :object_name, :object, :wrapper, :lookup_option
 
     # When action is create or update, we still should use new and edit
     ACTIONS = {
@@ -40,9 +40,10 @@ module SimpleForm
 
     def initialize(*) #:nodoc:
       super
-      @object   = convert_to_model(@object)
-      @defaults = options[:defaults]
-      @wrapper  = SimpleForm.wrapper(options[:wrapper] || SimpleForm.default_wrapper)
+      @object        = convert_to_model(@object)
+      @defaults      = options[:defaults]
+      @wrapper       = SimpleForm.wrapper(options[:wrapper] || SimpleForm.default_wrapper)
+      @lookup_option = options[:lookup]
     end
 
     # Basic input helper, combines all components in the stack to generate

--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -28,7 +28,7 @@ module SimpleForm
       attr_reader :attribute_name, :column, :input_type, :reflection,
                   :options, :input_html_options, :input_html_classes, :html_classes
 
-      delegate :template, :object, :object_name, :lookup_model_names, :lookup_action, to: :@builder
+      delegate :template, :object, :object_name, :lookup_model_names, :lookup_action, :lookup_option, to: :@builder
 
       class_attribute :default_options
       self.default_options = {}
@@ -179,9 +179,11 @@ module SimpleForm
           joined_model_names = model_names.join(".")
           model_names.shift
 
+          lookups << :"#{joined_model_names}.#{lookup_option}.#{reflection_or_attribute_name}" if lookup_option
           lookups << :"#{joined_model_names}.#{lookup_action}.#{reflection_or_attribute_name}"
           lookups << :"#{joined_model_names}.#{reflection_or_attribute_name}"
         end
+        lookups << :"defaults.#{lookup_option}.#{reflection_or_attribute_name}" if lookup_option
         lookups << :"defaults.#{lookup_action}.#{reflection_or_attribute_name}"
         lookups << :"defaults.#{reflection_or_attribute_name}"
         lookups << default

--- a/test/components/label_test.rb
+++ b/test/components/label_test.rb
@@ -41,6 +41,19 @@ class IsolatedLabelTest < ActionView::TestCase
     end
   end
 
+  test 'label uses i18n based on model, overrided lookup_action, and attribute to lookup translation' do
+    @controller.action_name = "new"
+    store_translations(:en, simple_form: { labels: { user: {
+      shared: { description: 'Nova descrição' }
+    } } }) do
+      with_concat_form_for(@user, lookup: :shared) do |f|
+        concat f.input :description
+      end
+
+      assert_select 'label[for=user_description]', /Nova descrição/
+    end
+  end
+
   test 'label fallbacks to new when action is create' do
     @controller.action_name = "create"
     store_translations(:en, simple_form: { labels: { user: {


### PR DESCRIPTION
### Additional builder param `lookup` for looking up locales for labels and hint
Feature Request: https://github.com/heartcombo/simple_form/issues/1464 (Solution B)


* It allows the user to specify additional lookup locales paths actions other than `new/create` and `edit/update`