### PR TITLE
Speed up nested #simple_fields_for usage by a considerable amount

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -672,12 +672,7 @@ module SimpleForm
 
     def attempt_mapping(mapping, at)
       return if SimpleForm.inputs_discovery == false && at == Object
-
-      begin
-        at.const_get(mapping)
-      rescue NameError => e
-        raise if e.message !~ /#{mapping}$/
-      end
+      return at.const_get(mapping) if at.const_defined?(mapping)
     end
 
     def attempt_mapping_with_custom_namespace(input_name)


### PR DESCRIPTION
The `FormBuilder#find_mapping` method is relying on `Object#const_get` raising an exception if the constant doesn't exist, rather than directly checking if it exists with `Object#const_defined?`.

Exceptions are slow due to generating backtraces - and then when other debugging gems (such as did_you mean, which are included with Ruby and Rails these days) get involved it resulted in excessive Object allocation.

Normally the `discovery_cache` would mitigate this, so there wouldn't be many calls to `#mapping_override`, however when you use `#simple_fields_for` with a collection/has_many association the cache is empty for each item in the collection.

Before this change this code was taking approximately 2 seconds and 2.9million allocations for 235 records:

```
<%= f.simple_fields_for :provider_access_masks, @access_masks do |pam| %>
  <%= pam.input :id, as: 'hidden' %>
  <%= pam.input :_destroy, as: 'boolean', label: "Delete", class: 'destroy' %>
<% end %>
```

After this change it was down to approximately 100ms and 200,000 allocations. (All on my M1 MacBook Air)