### PR TITLE
Pass base object to `human_attribute_name` for labels

### DIFF
--- a/lib/simple_form/components/labels.rb
+++ b/lib/simple_form/components/labels.rb
@@ -74,7 +74,7 @@ module SimpleForm
         if SimpleForm.translate_labels && (translated_label = translate_from_namespace(:labels))
           translated_label
         elsif object.class.respond_to?(:human_attribute_name)
-          object.class.human_attribute_name(reflection_or_attribute_name.to_s)
+          object.class.human_attribute_name(reflection_or_attribute_name.to_s, { base: object })
         else
           attribute_name.to_s.humanize
         end


### PR DESCRIPTION
When discovering translations, Rails [passes the `base` object to `human_attribute_name`](https://github.com/rails/rails/blob/af09d6b90b23c2d7389f879f37e9cbbeea078e5a/activemodel/lib/active_model/error.rb#L55). This is helpful because `human_attribute_name` is a class method and does not have access to instance methods. If someone wants to customize the behavior of said method based on properties of the instance, this is not possible without this argument. This merge request makes a tiny change to pass this base object.