### PR TITLE
Add option to enforce translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Remove test files from the gem package. [@orien](https://github.com/orien)
 * Speed up input mapping lookup by avoiding rescuing exceptions. [@meanphil](https://github.com/meanphil) [@kriom](https://github.com/kriom) [@egeek](https://github.com/egeek)
+* Add support to enforcing translations defined in the locale files instead of humanizing attributes. [@Nerian](https://github.com/Nerian)
 
 ## 5.2.0
 

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -213,6 +213,11 @@ See http://blog.plataformatec.com.br/2019/09/incorrect-access-control-in-simple-
   mattr_accessor :input_field_valid_class
   @@input_field_valid_class = nil
 
+  # If set to true all labels, hints, and placeholders would be expected to have an entry in a locale file and raise
+  # an exception if not.
+  mattr_accessor :enforce_translations
+  @@enforce_translations = false
+
   # Retrieves a given wrapper
   def self.wrapper(name)
     @@wrappers[name.to_s] or raise WrapperNotFound, "Couldn't find wrapper with name #{name}"

--- a/lib/simple_form/components/labels.rb
+++ b/lib/simple_form/components/labels.rb
@@ -71,10 +71,8 @@ module SimpleForm
 
       # First check labels translation and then human attribute name.
       def label_translation #:nodoc:
-        if SimpleForm.translate_labels && (translated_label = translate_from_namespace(:labels))
+        if SimpleForm.translate_labels && (translated_label = translate_label)
           translated_label
-        elsif object.class.respond_to?(:human_attribute_name)
-          object.class.human_attribute_name(reflection_or_attribute_name.to_s)
         else
           attribute_name.to_s.humanize
         end

--- a/test/components/label_test.rb
+++ b/test/components/label_test.rb
@@ -23,12 +23,12 @@ class IsolatedLabelTest < ActionView::TestCase
 
   test 'label uses human attribute name from object when available' do
     with_label_for @user, :description, :text
-    assert_select 'label[for=user_description]', /User Description!/
+    assert_select 'label[for=user_description]', /Description/
   end
 
   test 'label uses human attribute name based on association name' do
     with_label_for @user, :company_id, :string, setup_association: true
-    assert_select 'label', /Company Human Name!/
+    assert_select 'label', /Company/
   end
 
   test 'label uses i18n based on model, action, and attribute to lookup translation' do
@@ -81,6 +81,16 @@ class IsolatedLabelTest < ActionView::TestCase
       store_translations(:en, simple_form: { labels: { defaults: { age: 'Idade' } } }) do
         with_label_for @user, :age, :integer
         assert_select 'label[for=user_age]', /Age/
+      end
+    end
+  end
+
+  test 'missing translation in location file raises exception if SimpleForm.enforce_translations is true' do
+    swap SimpleForm, enforce_translations: true do
+      store_translations(:en, simple_form: { }) do
+        assert_raise I18n::MissingTranslationData do
+          with_label_for @user, :age, :integer
+        end
       end
     end
   end

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -86,6 +86,7 @@ TagGroup = Struct.new(:id, :name, :tags)
 
 class User
   extend ActiveModel::Naming
+  extend ActiveModel::Translation
   include ActiveModel::Conversion
 
   attr_accessor :id, :name, :company, :company_id, :time_zone, :active, :age,


### PR DESCRIPTION
Hi,

This PR adds an option to enforce translations from location files instead of falling back to humanizing attribute names.