### PR TITLE
Fix DatetimeInput so it respects html5 wrapper configuration

### DIFF
--- a/lib/simple_form/inputs/date_time_input.rb
+++ b/lib/simple_form/inputs/date_time_input.rb
@@ -5,7 +5,7 @@ module SimpleForm
       def input(wrapper_options = nil)
         merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
 
-        if use_html5_inputs?
+        if html5?
           @builder.send(:"#{input_type}_field", attribute_name, merged_input_options)
         else
           @builder.send(:"#{input_type}_select", attribute_name, input_options, merged_input_options)
@@ -15,25 +15,20 @@ module SimpleForm
       private
 
       def label_target
-        if use_html5_inputs?
-          attribute_name
+        return attribute_name if html5?
+
+        position = case input_type
+        when :date, :datetime
+          date_order = input_options[:order] || I18n.t('date.order')
+          date_order.first.to_sym
         else
-          position = case input_type
-          when :date, :datetime
-            date_order = input_options[:order] || I18n.t('date.order')
-            date_order.first.to_sym
-          else
-            :hour
-          end
-
-          position = ActionView::Helpers::DateTimeSelector::POSITION[position]
-          "#{attribute_name}_#{position}i"
+          :hour
         end
+
+        position = ActionView::Helpers::DateTimeSelector::POSITION[position]
+        "#{attribute_name}_#{position}i"
       end
 
-      def use_html5_inputs?
-        input_options[:html5]
-      end
     end
   end
 end

--- a/test/form_builder/general_test.rb
+++ b/test/form_builder/general_test.rb
@@ -221,22 +221,22 @@ class FormBuilderTest < ActionView::TestCase
 
   test 'builder generates date select for date columns' do
     with_form_for @user, :born_at
-    assert_select 'form select#user_born_at_1i.date'
+    assert_select 'form input#user_born_at.date'
   end
 
   test 'builder generates time select for time columns' do
     with_form_for @user, :delivery_time
-    assert_select 'form select#user_delivery_time_4i.time'
+    assert_select 'form input#user_delivery_time.time'
   end
 
   test 'builder generates datetime select for datetime columns' do
     with_form_for @user, :created_at
-    assert_select 'form select#user_created_at_1i.datetime'
+    assert_select 'form input#user_created_at.datetime'
   end
 
   test 'builder generates datetime select for timestamp columns' do
     with_form_for @user, :updated_at
-    assert_select 'form select#user_updated_at_1i.datetime'
+    assert_select 'form input#user_updated_at.datetime'
   end
 
   test 'builder generates file input for ActiveStorage >= 5.2 and Refile >= 0.2.0 <= 0.4.0' do
@@ -508,7 +508,7 @@ class FormBuilderTest < ActionView::TestCase
 
   test 'builder allows overriding input type when object is not present' do
     with_form_for :project, :created_at, as: :datetime
-    assert_select 'form select.datetime#project_created_at_1i'
+    assert_select 'form input.datetime#project_created_at'
     with_form_for :project, :budget, as: :decimal
     assert_select 'form input.decimal#project_budget'
   end

--- a/test/inputs/datetime_input_test.rb
+++ b/test/inputs/datetime_input_test.rb
@@ -4,61 +4,47 @@ require 'test_helper'
 
 # Tests for datetime, date and time inputs when HTML5 compatibility is enabled in the wrapper.
 class DateTimeInputWithHtml5Test < ActionView::TestCase
-  test 'input generates a datetime input for datetime attributes if HTML5 compatibility is explicitly enbled' do
-    with_input_for @user, :created_at, :datetime, html5: true
+
+  test 'input generates a datetime input for datetime attributes' do
+    with_input_for @user, :created_at, :datetime
     assert_select 'input[type="datetime-local"]'
   end
 
-  test 'input generates a datetime select for datetime attributes' do
-    with_input_for @user, :created_at, :datetime
-
-    assert_select 'select.datetime'
-  end
-
-  test 'input generates a date input for date attributes if HTML5 compatibility is explicitly enbled' do
-    with_input_for @user, :born_at, :date, html5: true
-
+  test 'input generates a date input for date attributes' do
+    with_input_for @user, :born_at, :date
     assert_select 'input[type="date"]'
   end
 
-  test 'input generates a date select for date attributes' do
-    with_input_for @user, :born_at, :date
-
-    assert_select 'select.date'
-  end
-
-  test 'input generates a time input for time attributes if HTML5 compatibility is explicitly enbled' do
-    with_input_for @user, :delivery_time, :time, html5: true
-
+  test 'input generates a time input for time attributes' do
+    with_input_for @user, :delivery_time, :time
     assert_select 'input[type="time"]'
   end
 
-  test 'input generates a time select for time attributes' do
-    with_input_for @user, :delivery_time, :time
-
-    assert_select 'select.time'
-  end
-
   test 'input generates required html attribute' do
-    with_input_for @user, :delivery_time, :time, required: true, html5: true
+    with_input_for @user, :delivery_time, :time, required: true
     assert_select 'input.required'
     assert_select 'input[required]'
   end
 
   test 'input has an aria-required html attribute' do
-    with_input_for @user, :delivery_time, :time, required: true, html5: true
+    with_input_for @user, :delivery_time, :time, required: true
     assert_select 'input[aria-required=true]'
   end
+
+  test 'label points to attribute name' do
+    with_input_for :project, :created_at, :date
+    assert_select 'label[for=project_created_at]'
+  end
+
 end
 
-# Tests for datetime, date and time inputs when HTML5 compatibility is enabled in the wrapper.
+# Tests for datetime, date and time inputs when HTML5 compatibility is disabled in the wrapper.
 class DateTimeInputWithoutHtml5Test < ActionView::TestCase
+
   test 'input generates a datetime select by default for datetime attributes' do
-    swap_wrapper do
-      with_input_for @user, :created_at, :datetime
-      1.upto(5) do |i|
-        assert_select "form select.datetime#user_created_at_#{i}i"
-      end
+    with_input_for @user, :created_at, :datetime, html5: false
+    1.upto(5) do |i|
+      assert_select "form select.datetime#user_created_at_#{i}i"
     end
   end
 
@@ -72,26 +58,17 @@ class DateTimeInputWithoutHtml5Test < ActionView::TestCase
     assert_select 'select.datetime option', 'dia'
   end
 
-  test 'input generates a datetime input for datetime attributes if HTML5 compatibility is explicitly enabled' do
-    swap_wrapper do
-      with_input_for @user, :created_at, :datetime, html5: true
-      assert_select 'input[type="datetime-local"]'
-    end
-  end
-
   test 'input generates a date select for date attributes' do
-    swap_wrapper do
-      with_input_for @user, :born_at, :date
-      assert_select 'select.date#user_born_at_1i'
-      assert_select 'select.date#user_born_at_2i'
-      assert_select 'select.date#user_born_at_3i'
-      assert_no_select 'select.date#user_born_at_4i'
-    end
+    with_input_for @user, :born_at, :date, html5: false
+    assert_select 'select.date#user_born_at_1i'
+    assert_select 'select.date#user_born_at_2i'
+    assert_select 'select.date#user_born_at_3i'
+    assert_no_select 'select.date#user_born_at_4i'
   end
 
   test 'input is able to pass options to date select' do
     with_input_for @user, :born_at, :date, as: :date, html5: false,
-      disabled: true, prompt: { year: 'ano', month: 'mês', day: 'dia' }
+       disabled: true, prompt: { year: 'ano', month: 'mês', day: 'dia' }
 
     assert_select 'select.date[disabled=disabled]'
     assert_select 'select.date option', 'ano'
@@ -104,23 +81,13 @@ class DateTimeInputWithoutHtml5Test < ActionView::TestCase
     assert_select "select.date option[value='#{Date.today.year}'][selected=selected]"
   end
 
-  test 'input generates a date input for date attributes if HTML5 compatibility is explicitly enabled' do
-    swap_wrapper do
-      with_input_for @user, :born_at, :date, html5: true
-
-      assert_select 'input[type="date"]'
-    end
-  end
-
   test 'input generates a time select for time attributes' do
-    swap_wrapper do
-      with_input_for @user, :delivery_time, :time
-      assert_select 'input[type=hidden]#user_delivery_time_1i'
-      assert_select 'input[type=hidden]#user_delivery_time_2i'
-      assert_select 'input[type=hidden]#user_delivery_time_3i'
-      assert_select 'select.time#user_delivery_time_4i'
-      assert_select 'select.time#user_delivery_time_5i'
-    end
+    with_input_for @user, :delivery_time, :time, html5: false
+    assert_select 'input[type=hidden]#user_delivery_time_1i'
+    assert_select 'input[type=hidden]#user_delivery_time_2i'
+    assert_select 'input[type=hidden]#user_delivery_time_3i'
+    assert_select 'select.time#user_delivery_time_4i'
+    assert_select 'select.time#user_delivery_time_5i'
   end
 
   test 'input is able to pass options to time select' do
@@ -130,14 +97,6 @@ class DateTimeInputWithoutHtml5Test < ActionView::TestCase
     assert_select 'select.time[disabled=disabled]'
     assert_select 'select.time option', 'hora'
     assert_select 'select.time option', 'minuto'
-  end
-
-  test 'input generates a time input for time attributes if HTML5 compatibility is explicitly enabled' do
-    swap_wrapper do
-      with_input_for @user, :delivery_time, :time, html5: true
-
-      assert_select 'input[type="time"]'
-    end
   end
 
   test 'label uses i18n to get target for date input type' do
@@ -169,8 +128,4 @@ class DateTimeInputWithoutHtml5Test < ActionView::TestCase
     assert_select 'label[for=project_created_at_4i]'
   end
 
-  test 'label points to attribute name if HTML5 compatibility is explicitly enabled' do
-    with_input_for :project, :created_at, :date, html5: true
-    assert_select 'label[for=project_created_at]'
-  end
 end

--- a/test/inputs/disabled_test.rb
+++ b/test/inputs/disabled_test.rb
@@ -19,12 +19,12 @@ class DisabledTest < ActionView::TestCase
 
   test 'date input is disabled when disabled option is true' do
     with_input_for @user, :born_at, :date, disabled: true
-    assert_select 'select.date.disabled[disabled]'
+    assert_select 'input.date.disabled[disabled]'
   end
 
   test 'datetime input is disabled when disabled option is true' do
     with_input_for @user, :created_at, :datetime, disabled: true
-    assert_select 'select.datetime.disabled[disabled]'
+    assert_select 'input.datetime.disabled[disabled]'
   end
 
   test 'string input does not be disabled when disabled option is false' do

--- a/test/inputs/general_test.rb
+++ b/test/inputs/general_test.rb
@@ -11,9 +11,9 @@ class InputTest < ActionView::TestCase
     with_input_for @user, :age, :integer
     assert_select 'input.integer'
     with_input_for @user, :born_at, :date
-    assert_select 'select.date'
+    assert_select 'input.date'
     with_input_for @user, :created_at, :datetime
-    assert_select 'select.datetime'
+    assert_select 'input.datetime'
   end
 
   test 'string input generates autofocus attribute when autofocus option is true' do
@@ -49,12 +49,12 @@ class InputTest < ActionView::TestCase
 
   test 'date input generates autofocus attribute when autofocus option is true' do
     with_input_for @user, :born_at, :date, autofocus: true
-    assert_select 'select.date[autofocus]'
+    assert_select 'input.date[autofocus]'
   end
 
   test 'datetime input generates autofocus attribute when autofocus option is true' do
     with_input_for @user, :created_at, :datetime, autofocus: true
-    assert_select 'select.datetime[autofocus]'
+    assert_select 'input.datetime[autofocus]'
   end
 
   test 'string input generates autofocus attribute when autofocus option is false' do
@@ -74,12 +74,12 @@ class InputTest < ActionView::TestCase
 
   test 'date input generates autofocus attribute when autofocus option is false' do
     with_input_for @user, :born_at, :date, autofocus: false
-    assert_no_select 'select.date[autofocus]'
+    assert_no_select 'input.date[autofocus]'
   end
 
   test 'datetime input generates autofocus attribute when autofocus option is false' do
     with_input_for @user, :created_at, :datetime, autofocus: false
-    assert_no_select 'select.datetime[autofocus]'
+    assert_no_select 'input.datetime[autofocus]'
   end
 
   test 'string input generates autofocus attribute when autofocus option is not present' do
@@ -99,12 +99,12 @@ class InputTest < ActionView::TestCase
 
   test 'date input generates autofocus attribute when autofocus option is not present' do
     with_input_for @user, :born_at, :date
-    assert_no_select 'select.date[autofocus]'
+    assert_no_select 'input.date[autofocus]'
   end
 
   test 'datetime input generates autofocus attribute when autofocus option is not present' do
     with_input_for @user, :created_at, :datetime
-    assert_no_select 'select.datetime[autofocus]'
+    assert_no_select 'input.datetime[autofocus]'
   end
 
   # With no object

--- a/test/inputs/readonly_test.rb
+++ b/test/inputs/readonly_test.rb
@@ -19,12 +19,12 @@ class ReadonlyTest < ActionView::TestCase
 
   test 'date input generates readonly elements when readonly option is true' do
     with_input_for @user, :born_at, :date, readonly: true
-    assert_select 'select.date.readonly[readonly]'
+    assert_select 'input.date.readonly[readonly]'
   end
 
   test 'datetime input generates readonly elements when readonly option is true' do
     with_input_for @user, :created_at, :datetime, readonly: true
-    assert_select 'select.datetime.readonly[readonly]'
+    assert_select 'input.datetime.readonly[readonly]'
   end
 
   test 'string input generates readonly elements when readonly option is false' do


### PR DESCRIPTION
Bug fix for #1739

I reorganized the tests a little bit. Tests which should generate html5 inputs were consolidated under `DateTimeInputWithHtml5Test` and tests which shouldn't generate html5 inputs were consolidated under `DateTimeInputWithoutHtml5Test`.

I also removed some unnecessary calls to `swap_wrapper` since the default wrapper supports optional use of the html5 component.