### PR TITLE
Pin country_select version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ If you want to use the country select, you will need the
 [country_select gem](https://rubygems.org/gems/country_select), add it to your Gemfile:
 
 ```ruby
-gem 'country_select'
+gem 'country_select', '~> 8.0.3'
 ```
 
 If you don't want to use the gem you can easily override this behaviour by mapping the


### PR DESCRIPTION
The latest release of Simple Form breaks with `country_select` 9.0.0