### PR TITLE
Fix encrypted attributes improperly casted

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -599,7 +599,11 @@ module SimpleForm
 
     def find_attribute_column(attribute_name)
       if @object.respond_to?(:type_for_attribute) && @object.has_attribute?(attribute_name)
-        @object.type_for_attribute(attribute_name.to_s)
+        detected_type = @object.type_for_attribute(attribute_name.to_s)
+
+        # Some attributes like ActiveRecord::Encryption::EncryptedAttribute are detected
+        # as different type, in that case we need to use the original type
+        detected_type.respond_to?(:cast_type) ? detected_type.cast_type : detected_type
       elsif @object.respond_to?(:column_for_attribute) && @object.has_attribute?(attribute_name)
         @object.column_for_attribute(attribute_name)
       end


### PR DESCRIPTION
This PR fixes a bug introduced by ActiveRecord::Encrypted attributes. 
Instead of returning a `ActiveModel::Type::String` like they used to, encrypted attributes return an instance of `ActiveRecord::Encryption::EncryptedAttributeType`, on which you need to call `#cast_type` in order to obtain the original type. 

To fix this, I check whether or not the attribute `#responds_to?(:cast_type)` which would indicate that we need to take into account the underlying type instead of just `#type_for_attribute`.

Checking this instead of checking if the `attribute_name` `#responds_to?(:encrypted_attributes)` allows to take into account other forms of type overriding that ActiveRecord may introduce in the future or potentially already exist. 

See the type difference below between a regular string attribute and an encrypted attribute
![image](https://github.com/heartcombo/simple_form/assets/4990201/41ada727-8776-4660-a2dd-0bbf1ba1ee83)


Fixes https://github.com/heartcombo/simple_form/issues/1829