### PR TITLE
Allow to give an object's method name as symbol define collection

### DIFF
--- a/lib/simple_form/inputs/collection_input.rb
+++ b/lib/simple_form/inputs/collection_input.rb
@@ -33,7 +33,12 @@ module SimpleForm
 
       def collection
         @collection ||= begin
-          collection = options.delete(:collection) || self.class.boolean_collection
+          collection_option = options.delete(:collection) || self.class.boolean_collection
+          if collection_option.is_a?(Symbol)
+            collection = self.object.send(collection_option)
+          else
+            collection = collection_option
+          end
           collection.respond_to?(:call) ? collection.call : collection.to_a
         end
       end

--- a/test/inputs/collection_select_input_test.rb
+++ b/test/inputs/collection_select_input_test.rb
@@ -65,6 +65,12 @@ class CollectionSelectInputTest < ActionView::TestCase
     assert_select 'select option[selected=selected]', '18'
   end
 
+  test 'input support to give a method name as symbol to define the collection' do
+    @user.locale = :"ja-JP"
+    with_input_for @user, :locale, :select, collection: :locales
+    assert_select 'select option[selected=selected]', "ja-JP"
+  end
+
   test 'input marks the selected value when using booleans and select' do
     @user.active = false
     with_input_for @user, :active, :select

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -92,7 +92,7 @@ class User
     :description, :created_at, :updated_at, :credit_limit, :password, :url,
     :delivery_time, :born_at, :special_company_id, :country, :tags, :tag_ids,
     :avatar, :home_picture, :email, :status, :residence_country, :phone_number,
-    :post_count, :lock_version, :amount, :attempts, :action, :credit_card, :gender,
+    :post_count, :lock_version, :amount, :attempts, :action, :credit_card, :locale, :gender,
     :extra_special_company_id, :pictures, :picture_ids, :special_pictures,
     :special_picture_ids, :uuid, :friends, :friend_ids, :special_tags, :special_tag_ids,
     :citext, :hstore, :json, :jsonb, :hourly, :favorite_color
@@ -146,9 +146,14 @@ class User
       when :attempts      then :integer
       when :action        then :string
       when :credit_card   then :string
+      when :locale        then :string
       else attribute.to_sym
     end
     Column.new(attribute, column_type, limit)
+  end
+
+  def locales
+    [:"en-US", :"fr-FR", :"es-ES", :"ja-JP", :"zh-CN"]
   end
 
   begin


### PR DESCRIPTION
Hi,

I would like to be able to give a method as symbol for the collection
with, for example
```ruby
class User
  #...
  def locales
    [:"en-US", :"fr-FR", :"es-ES", :"ja-JP", :"zh-CN"]
  end
  #...
end
```
I would like to do that in my view
```ruby
form.input(:locale, collection: :locales, include_blank: false)
```
rather than :
```ruby
form.input(:locale, collection: form.object.locales, include_blank: false)
```
Is it feasible? ?