### PR TITLE
Integrate `:rich_text_area` with placeholders

### DIFF
--- a/lib/simple_form/inputs/rich_text_area_input.rb
+++ b/lib/simple_form/inputs/rich_text_area_input.rb
@@ -2,6 +2,8 @@
 module SimpleForm
   module Inputs
     class RichTextAreaInput < Base
+      enable :placeholder
+
       def input(wrapper_options = nil)
         merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
 


### PR DESCRIPTION
Trix (the rich text editor that's rendered by Action View's form builder) has supported the `[placeholder]` attribute since at least version [0.9.0][] (and continues to support it in [2.1.1][].

This commit enables `:placeholder` support in the
`SimpleForm::Inputs::RichTextAreaInput` class to transform placeholder internationalization strings into `trix-editor[placeholder]` HTML attributes.

[0.9.0]: https://github.com/basecamp/trix/tree/0.9.0?tab=readme-ov-file#creating-an-editor
[2.1.1]: https://github.com/basecamp/trix/tree/v2.1.1?tab=readme-ov-file#creating-an-editor