### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ See http://blog.plataformatec.com.br/2019/09/incorrect-access-control-in-simple-
 ### Bug fix
 * Fix horizontal form label position, from right to text-right. [@cavpollo](https://github.com/cavpollo)
 * Add base error display alongside existing errors. [@bluefalcon26](https://github.com/bluefalcon26)
-* Silent deprication warning for placeholder_text. [@moofkit](https://github.com/moofkit)
+* Silent deprecation warning for placeholder_text. [@moofkit](https://github.com/moofkit)
 * Use custom i18n scope for label required html. [@tvdeyen](https://github.com/tvdeyen)
 
 ## 3.5.1
@@ -232,7 +232,7 @@ See http://blog.plataformatec.com.br/2019/09/incorrect-access-control-in-simple-
 
 ### bug fix
   * Fix `full_error` when the attribute is an association. [@mvdamme](https://github.com/jorge-d)
-  * Fix suppport to `:namespace` and `:index` options for nested check boxes and radio buttons when the attribute is an association.
+  * Fix support to `:namespace` and `:index` options for nested check boxes and radio buttons when the attribute is an association.
   * Collection input that uses automatic collection translation properly sets checked values.
   Closes [#971](https://github.com/heartcombo/simple_form/issues/971) [@nashby](https://github.com/nashby)
   * Collection input generates `required` attribute if it has `prompt` option. [@nashby](https://github.com/nashby)

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -73,11 +73,11 @@ See http://blog.plataformatec.com.br/2019/09/incorrect-access-control-in-simple-
   mattr_accessor :error_notification_class
   @@error_notification_class = :error_notification
 
-  # Series of attemps to detect a default label method for collection.
+  # Series of attempts to detect a default label method for collection.
   mattr_accessor :collection_label_methods
   @@collection_label_methods = %i[to_label name title to_s]
 
-  # Series of attemps to detect a default value method for collection.
+  # Series of attempts to detect a default value method for collection.
   mattr_accessor :collection_value_methods
   @@collection_value_methods = %i[id to_s]
 
@@ -178,7 +178,7 @@ See http://blog.plataformatec.com.br/2019/09/incorrect-access-control-in-simple-
   mattr_accessor :cache_discovery
   @@cache_discovery = defined?(Rails.env) && !Rails.env.development?
 
-  # Adds a class to each generated button, mostly for compatiblity.
+  # Adds a class to each generated button, mostly for compatibility.
   mattr_accessor :button_class
   @@button_class = 'button'
 

--- a/test/action_view_extensions/builder_test.rb
+++ b/test/action_view_extensions/builder_test.rb
@@ -269,7 +269,7 @@ class BuilderTest < ActionView::TestCase
     end
   end
   # COLLECTION CHECK BOX
-  test "collection check box accepts a collection and generate a serie of checkboxes for value method" do
+  test "collection check box accepts a collection and generate a series of checkboxes for value method" do
     collection = [Tag.new(1, 'Tag 1'), Tag.new(2, 'Tag 2')]
     with_collection_check_boxes @user, :tag_ids, collection, :id, :name
 
@@ -284,7 +284,7 @@ class BuilderTest < ActionView::TestCase
     assert_select "form input[type=hidden][name='user[tag_ids][]'][value='']", count: 1
   end
 
-  test "collection check box accepts a collection and generate a serie of checkboxes with labels for label method" do
+  test "collection check box accepts a collection and generate a series of checkboxes with labels for label method" do
     collection = [Tag.new(1, 'Tag 1'), Tag.new(2, 'Tag 2')]
     with_collection_check_boxes @user, :tag_ids, collection, :id, :name
 
@@ -585,7 +585,7 @@ class BuilderTest < ActionView::TestCase
     end
   end
 
-  test "fields for with a hash like model yeilds an instance of FormBuilder" do
+  test "fields for with a hash like model yields an instance of FormBuilder" do
     with_concat_form_for(:user) do |f|
       f.simple_fields_for(:author, HashBackedAuthor.new) do |author|
         assert author.instance_of?(SimpleForm::FormBuilder)

--- a/test/form_builder/label_test.rb
+++ b/test/form_builder/label_test.rb
@@ -104,7 +104,7 @@ class LabelTest < ActionView::TestCase
     end
   end
 
-  test 'configuration allow set rewrited label tag for wrappers' do
+  test 'configuration allow set rewritten label tag for wrappers' do
     swap_wrapper :default, custom_wrapper_with_custom_label_component do
       with_concat_form_for(@user) do |f|
         concat f.input :age

--- a/test/inputs/collection_select_input_test.rb
+++ b/test/inputs/collection_select_input_test.rb
@@ -220,7 +220,7 @@ class CollectionSelectInputTest < ActionView::TestCase
     assert_select 'select option[value="2"]', 'Carlos'
   end
 
-  test 'input disables the anothers components when the option is a object' do
+  test 'input disables all options when the entire select is disabled' do
     with_input_for @user, :description, :select, collection: %w[Jose Carlos], disabled: true
     assert_no_select 'select option[value=Jose][disabled=disabled]', 'Jose'
     assert_no_select 'select option[value=Carlos][disabled=disabled]', 'Carlos'
@@ -228,7 +228,7 @@ class CollectionSelectInputTest < ActionView::TestCase
     assert_select 'div.disabled'
   end
 
-  test 'input does not disable the anothers components when the option is a object' do
+  test 'input disables only specific options when individual options are disabled' do
     with_input_for @user, :description, :select, collection: %w[Jose Carlos], disabled: 'Jose'
     assert_select 'select option[value=Jose][disabled=disabled]', 'Jose'
     assert_no_select 'select option[value=Carlos][disabled=disabled]', 'Carlos'

--- a/test/inputs/discovery_test.rb
+++ b/test/inputs/discovery_test.rb
@@ -66,7 +66,7 @@ class DiscoveryTest < ActionView::TestCase
     end
   end
 
-  test 'builder discovers new maped inputs from configured namespaces if not cached' do
+  test 'builder discovers new mapped inputs from configured namespaces if not cached' do
     discovery do
       swap SimpleForm, custom_inputs_namespaces: ['CustomInputs'] do
         with_form_for @user, :password
@@ -75,7 +75,7 @@ class DiscoveryTest < ActionView::TestCase
     end
   end
 
-  test 'builder discovers new maped inputs from configured namespaces before the ones from top level namespace' do
+  test 'builder discovers new mapped inputs from configured namespaces before the ones from top level namespace' do
     discovery do
       swap SimpleForm, custom_inputs_namespaces: ['CustomInputs'] do
         with_form_for @user, :age


### PR DESCRIPTION
Found with `codespell`, plus manual fixes