### PR TITLE
remove default form_class

### DIFF
--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -113,10 +113,9 @@ See http://blog.plataformatec.com.br/2019/09/incorrect-access-control-in-simple-
   mattr_accessor :boolean_style
   @@boolean_style = :inline
 
-  # DEPRECATED: You can define the class to be used on all forms. Default is
-  # simple_form.
+  # DEPRECATED: You can define the class to be used on all forms. Default is none.
   mattr_reader :form_class
-  @@form_class = :simple_form
+  @@form_class = nil
 
   # You can define the default class to be used on all forms. Can be overridden
   # with `html: { :class }`. Defaults to none.


### PR DESCRIPTION
# Why

`form_class` is deprecated (has been for 10 years). It doesn't make sense that it's setting a class

# What

change the default. Please can get back the legacy behaviour by setting `default_form_class = :simple_form`