### PR TITLE
DOC: fix wrong description about asterisk positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ any html attribute to that wrapper as well using the `:wrapper_html` option, lik
 <% end %>
 ```
 
-Required fields are marked with an * prepended to their labels.
+Required fields are marked with an * appended to their labels.
 
 By default all inputs are required. When the form object includes `ActiveModel::Validations`
 (which, for example, happens with Active Record models), fields are required only when there is `presence` validation.


### PR DESCRIPTION
Hello, I'm not entirely sure, but it seems like the default behavior is to append and not to prepend.

Code is here https://github.com/nizarhmain/simple_form/blob/1abb8e1209caa289d680c4199e7627a53a70e996/lib/simple_form/components/labels.rb#L8-L12