### PR TITLE
Fix collection option being ignored for priority inputs (time_zone and country)

### DIFF
--- a/lib/simple_form/inputs/priority_input.rb
+++ b/lib/simple_form/inputs/priority_input.rb
@@ -3,6 +3,8 @@ module SimpleForm
   module Inputs
     class PriorityInput < CollectionSelectInput
       def input(wrapper_options = nil)
+        return super if options[:collection]
+
         merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
 
         send(:"#{input_type}_input", merged_input_options)

--- a/test/inputs/country_input_test.rb
+++ b/test/inputs/country_input_test.rb
@@ -30,6 +30,14 @@ class CountryInputTest < ActionView::TestCase
     assert_select %(select option[value="UA"] + #{COUNTRY_SELECT_SEPARATOR})
   end
 
+  test 'input generates a country select with a custom collection' do
+    with_input_for @user, :country, :country, collection: [['Brazil', 'BR'], ['Ukraine', 'UA']]
+    assert_select 'select#user_country'
+    assert_select 'select option', count: 3 # 2 countries + include_blank
+    assert_select 'select option[value=BR]', 'Brazil'
+    assert_select 'select option[value=UA]', 'Ukraine'
+  end
+
   test 'input does generate select element with required html attribute' do
     with_input_for @user, :country, :country
     assert_select 'select.required'

--- a/test/inputs/time_zone_input_test.rb
+++ b/test/inputs/time_zone_input_test.rb
@@ -22,6 +22,22 @@ class TimeZoneInputTest < ActionView::TestCase
     assert_no_select 'select option[value=""]', /^$/
   end
 
+  test 'input generates a time zone select with a custom collection' do
+    with_input_for @user, :time_zone, :time_zone, collection: [['London', 'London'], ['Berlin', 'Berlin']]
+    assert_select 'select#user_time_zone'
+    assert_select 'select option', count: 3 # 2 zones + include_blank
+    assert_select 'select option[value=London]', 'London'
+    assert_select 'select option[value=Berlin]', 'Berlin'
+  end
+
+  test 'input generates a time zone select with ActiveSupport::TimeZone objects' do
+    collection = ['London', 'Berlin'].map { |tz| ActiveSupport::TimeZone[tz] }
+
+    with_input_for @user, :time_zone, :time_zone, collection: collection, include_blank: false
+    assert_select 'select#user_time_zone'
+    assert_select 'select option', count: 2
+  end
+
   test 'input does generate select element with required html attribute' do
     with_input_for @user, :time_zone, :time_zone
     assert_select 'select.required'


### PR DESCRIPTION
Fixes #1851

### Problem

When `collection:` was passed to a `time_zone` or `country` input, it was silently ignored — all options were still rendered.

This also affects country inputs, as [reported by @Tressa-Sanders](https://github.com/heartcombo/simple_form/issues/1851#issuecomment-2345871424).

### Root cause

`PriorityInput#input` always delegates directly to `time_zone_select` / `country_select`, bypassing the parent `CollectionSelectInput#input` which is responsible for rendering the `collection:` option.

### Solution

Delegate to `super` when `collection:` is present, so the built-in collection rendering in `CollectionSelectInput` takes over.

### Known limitation

When `collection:` is given, `priority:` (and the global `SimpleForm.time_zone_priority` / `SimpleForm.country_priority` configuration) will not produce priority separators, because `CollectionSelectInput` uses `collection_select` rather than the native `time_zone_select` / `country_select` helpers. This matches the natural division of responsibilities: `collection:` opts into generic collection rendering.

Supporting both simultaneously would require rethinking the `PriorityInput` architecture and could be addressed in a follow-up.

### Tests added

- `collection:` with `[label, value]` pairs (time_zone + country)
- `collection:` with `ActiveSupport::TimeZone` objects (reproduces the exact code from #1851)

All 809 tests pass.