### PR TITLE
Fix label `for` not matching input `id` when collection value is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Ruby 4.0 support (no changes required)
 * Support procs on validators for minlength/maxlength, and improve validators logic across the board to match Rails [#1859](https://github.com/heartcombo/simple_form/pull/1859)
+* Fix label `for` attribute not matching input `id` when collection contains a nil value [#1840](https://github.com/heartcombo/simple_form/issues/1840)
 
 ## 5.4.0
 

--- a/lib/simple_form/tags.rb
+++ b/lib/simple_form/tags.rb
@@ -26,6 +26,20 @@ module SimpleForm
         end.join.html_safe
       end
 
+      # Override Rails' sanitize_attribute_name to avoid generating a trailing
+      # underscore when the collection value is nil (e.g. "method_" instead of
+      # "method"), which causes the label's `for` attribute to not match the
+      # input's `id`. See https://github.com/heartcombo/simple_form/issues/1840
+      def sanitize_attribute_name(value)
+        sanitized = sanitized_value(value)
+
+        if sanitized.empty?
+          sanitized_method_name.dup
+        else
+          "#{sanitized_method_name}_#{sanitized}"
+        end
+      end
+
       def wrap_rendered_collection(collection)
         wrapper_tag = @options[:collection_wrapper_tag]
 

--- a/test/inputs/collection_check_boxes_input_test.rb
+++ b/test/inputs/collection_check_boxes_input_test.rb
@@ -314,4 +314,24 @@ class CollectionCheckBoxesInputTest < ActionView::TestCase
       assert_select 'label.beautiful-label', count: 2
     end
   end
+
+  test 'input check boxes label for attribute matches input id when collection contains nil value' do
+    with_input_for @user, :name, :check_boxes, collection: [['Yes', true], ['Undefined', nil]]
+
+    assert_select 'input[type=checkbox][value=true]#user_name_true'
+    assert_select 'label.collection_check_boxes[for=user_name_true]', 'Yes'
+    assert_select 'input[type=checkbox]#user_name'
+    assert_select 'label.collection_check_boxes[for=user_name]', 'Undefined'
+    assert_no_select 'label[for=user_name_]'
+  end
+
+  test 'input check boxes with nested style label for attribute matches input id when collection contains nil value' do
+    swap SimpleForm, boolean_style: :nested do
+      with_input_for @user, :name, :check_boxes, collection: [['Yes', true], ['Undefined', nil]]
+
+      assert_select 'label[for=user_name_true]'
+      assert_select 'label[for=user_name]'
+      assert_no_select 'label[for=user_name_]'
+    end
+  end
 end

--- a/test/inputs/collection_radio_buttons_input_test.rb
+++ b/test/inputs/collection_radio_buttons_input_test.rb
@@ -437,4 +437,24 @@ class CollectionRadioButtonsInputTest < ActionView::TestCase
       assert_select 'label.beautiful-label', count: 2
     end
   end
+
+  test 'input radio label for attribute matches input id when collection contains nil value' do
+    with_input_for @user, :name, :radio_buttons, collection: [['Yes', true], ['Undefined', nil]]
+
+    assert_select 'input[type=radio][value=true]#user_name_true'
+    assert_select 'label.collection_radio_buttons[for=user_name_true]', 'Yes'
+    assert_select 'input[type=radio]#user_name'
+    assert_select 'label.collection_radio_buttons[for=user_name]', 'Undefined'
+    assert_no_select 'label[for=user_name_]'
+  end
+
+  test 'input radio with nested style label for attribute matches input id when collection contains nil value' do
+    swap SimpleForm, boolean_style: :nested do
+      with_input_for @user, :name, :radio_buttons, collection: [['Yes', true], ['Undefined', nil]]
+
+      assert_select 'label[for=user_name_true]'
+      assert_select 'label[for=user_name]'
+      assert_no_select 'label[for=user_name_]'
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1840.

### Problem

When a collection contains a `nil` value, the generated label's `for` attribute does not match the corresponding input's `id`:

```erb
<%= form.input :my_method, as: :radio_buttons,
      collection: [['Yes', true], ['Undefined', nil]] %>
```

produces:

```html
<!-- ✅ "true" — matches -->
<input id="model_my_method_true" type="radio" value="true" />
<label for="model_my_method_true">Yes</label>

<!-- ❌ nil — trailing underscore mismatch -->
<input id="model_my_method" type="radio" value="" />
<label for="model_my_method_">Undefined</label>
```

Clicking the "Undefined" label does **not** select its radio button because the `for` / `id` values differ by a single trailing underscore.

### Cause

Rails' [`sanitize_attribute_name`](https://github.com/rails/rails/blob/db4bd562d90427c21a4525412c25372dd6994a65/actionview/lib/action_view/helpers/tags/collection_helpers.rb#L71-L73) unconditionally interpolates an underscore separator:

```ruby
def sanitize_attribute_name(value)
  "#{sanitized_method_name}_#{sanitized_value(value)}"
end
```

When `value` is `nil`, `sanitized_value(nil)` returns `""`, producing `"my_method_"` (trailing underscore). This value is passed to the label builder as the method name, which generates `for="model_my_method_"`.

Meanwhile, the radio button's `id` is generated by `add_default_name_and_id_for_value`, which has a **separate** nil-check that skips the value suffix entirely, producing `id="model_my_method"` (no trailing underscore).

### Fix

Override `sanitize_attribute_name` in `SimpleForm::Tags::CollectionExtensions` to skip the underscore when the sanitized value is empty:

```ruby
def sanitize_attribute_name(value)
  sanitized = sanitized_value(value)

  if sanitized.empty?
    sanitized_method_name.dup
  else
    "#{sanitized_method_name}_#{sanitized}"
  end
end
```

This aligns the label's `for` with the input's `id` for both `collection_radio_buttons` and `collection_check_boxes`, in both inline and nested boolean styles.