### PR TITLE
Add `label_for` option to wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Add `label_for` option to wrappers, allowing label wrapper tags to automatically include the `for` attribute pointing to the corresponding input. [#1868](https://github.com/heartcombo/simple_form/pull/1868)
+
 ## 5.4.1
 
 * Ruby 4.0 support (no changes required)

--- a/lib/simple_form/wrappers/many.rb
+++ b/lib/simple_form/wrappers/many.rb
@@ -59,11 +59,24 @@ module SimpleForm
         klass = html_classes(input, options)
         opts  = html_options(options)
         opts[:class] = (klass << opts[:class]).join(' ').strip unless klass.empty?
+
+        if @defaults[:label_for]
+          opts[:for] ||= resolve_label_for(input)
+        end
+
         input.template.content_tag(tag, content, opts)
       end
 
       def html_options(options)
         (@defaults[:html] || {}).merge(options[:"#{namespace}_html"] || {})
+      end
+
+      def resolve_label_for(input)
+        if input.options.key?(:input_html) && input.options[:input_html].key?(:id)
+          input.options[:input_html][:id]
+        else
+          input.template.field_id(input.object_name, input.attribute_name)
+        end
       end
 
       def html_classes(input, options)

--- a/test/form_builder/wrapper_test.rb
+++ b/test/form_builder/wrapper_test.rb
@@ -375,4 +375,54 @@ class WrapperTest < ActionView::TestCase
       assert_no_select 'p.omg_hint'
     end
   end
+
+  # label_for option tests
+
+  test 'wrapper with label_for adds for attribute to label tag' do
+    swap_wrapper :default, custom_wrapper_with_label_for do
+      with_form_for @user, :name
+      assert_select 'div.custom_wrapper label.label-wrapper[for=user_name]'
+    end
+  end
+
+  test 'wrapper with label_for uses custom input id when input_html id is given' do
+    swap_wrapper :default, custom_wrapper_with_label_for do
+      with_form_for @user, :name, input_html: { id: 'my_custom_id' }
+      assert_select 'div.custom_wrapper label.label-wrapper[for=my_custom_id]'
+    end
+  end
+
+  test 'wrapper with label_for does not override for attribute from html options' do
+    swap_wrapper :default, custom_wrapper_with_label_for_and_html_for do
+      with_form_for @user, :name
+      assert_select 'div.custom_wrapper label.label-wrapper[for=custom_for]'
+    end
+  end
+
+  test 'wrapper without label_for does not add for attribute to label tag' do
+    custom = SimpleForm.build tag: :div, class: "custom_wrapper" do |b|
+      b.wrapper tag: :label, class: "label-wrapper" do |c|
+        c.use :input
+      end
+    end
+
+    swap_wrapper :default, custom do
+      with_form_for @user, :name
+      assert_select 'div.custom_wrapper label.label-wrapper'
+      assert_no_select 'div.custom_wrapper label.label-wrapper[for]'
+    end
+  end
+
+  test 'wrapper with label_for resolves correct id for nested forms' do
+    @user.company = Company.new(1, 'Empresa')
+    swap_wrapper :default, custom_wrapper_with_label_for do
+      with_concat_form_for @user do |f|
+        concat(f.simple_fields_for(:company) do |company_form|
+          concat(company_form.input :name)
+        end)
+      end
+
+      assert_select 'div.custom_wrapper label.label-wrapper[for=user_company_attributes_name]'
+    end
+  end
 end

--- a/test/support/misc_helpers.rb
+++ b/test/support/misc_helpers.rb
@@ -220,6 +220,22 @@ module MiscHelpers
     end
   end
 
+  def custom_wrapper_with_label_for
+    SimpleForm.build tag: :div, class: "custom_wrapper" do |b|
+      b.wrapper tag: :label, label_for: true, class: "label-wrapper" do |c|
+        c.use :input
+      end
+    end
+  end
+
+  def custom_wrapper_with_label_for_and_html_for
+    SimpleForm.build tag: :div, class: "custom_wrapper" do |b|
+      b.wrapper tag: :label, label_for: true, class: "label-wrapper", html: { for: "custom_for" } do |c|
+        c.use :input
+      end
+    end
+  end
+
   def custom_form_for(object, *args, &block)
     simple_form_for(object, *args, { builder: CustomFormBuilder }, &block)
   end


### PR DESCRIPTION
Closes #1800

When building custom wrappers with `tag: :label`, there was no way to automatically add the `for` attribute pointing to the corresponding input element.

This PR adds a `label_for` option to the wrapper DSL. When set to `true`, the wrapper resolves the input's `id` and adds it as the `for` attribute on the wrapping element.

### Usage

```ruby
config.wrappers :custom_label do |b|
  b.wrapper tag: :label, label_for: true, class: "custom-label" do |c|
    c.use :input
    c.wrapper tag: :div do |d|
      d.use :hint
    end
  end
end
```

This produces:

```html
<label for="user_name" class="custom-label">
  <input type="text" id="user_name" />
  <div>
    <span class="hint">...</span>
  </div>
</label>
```

### How it works

- `label_for: true` is opt-in — existing wrappers are not affected
- If `input_html: { id: "custom_id" }` is provided, that value is used
- Otherwise, `field_id` (Rails 7.0+) generates the standard input ID
- A `for` attribute set via `html: { for: "..." }` takes precedence (`||=`)
- Works correctly with nested forms (`simple_fields_for`) — `field_id` sanitizes the full `object_name` path consistently with Rails' input ID generation