### PR TITLE
Fix misleading comment in README about browser_validations default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1170,7 +1170,7 @@ If you want to have all other HTML 5 features, such as the new field types, you 
 the browser validation:
 
 ```ruby
-SimpleForm.browser_validations = false # default is true
+SimpleForm.browser_validations = false
 ```
 
 This option adds a new `novalidate` property to the form, instructing it to skip all HTML 5


### PR DESCRIPTION
The README contains a code example with a comment stating `# default is true`:

```ruby
SimpleForm.browser_validations = false # default is true
```

While `true` is the default in `lib/simple_form.rb`, the generator intentionally sets it to `false` in the initializer (see #319). This has caused recurring confusion, as reported in #1216 and #1746.

This PR removes the misleading inline comment so that users are not led to believe their app is running with `browser_validations = true` after running the generator.

Fixes #1746
