### PR TITLE
Fix I18n lookup when child_index contains non-word characters

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -473,8 +473,9 @@ module SimpleForm
     def lookup_model_names #:nodoc:
       @lookup_model_names ||= begin
         child_index = options[:child_index]
-        names = object_name.to_s.scan(/(?!\d)\w+/).flatten
-        names.delete(child_index) if child_index
+        name = object_name.to_s
+        name = name.gsub("[#{child_index}]", '') if child_index
+        names = name.scan(/(?!\d)\w+/).flatten
         names.each { |name| name.gsub!('_attributes', '') }
         names.freeze
       end

--- a/test/components/label_test.rb
+++ b/test/components/label_test.rb
@@ -165,6 +165,25 @@ class IsolatedLabelTest < ActionView::TestCase
     end
   end
 
+  test 'label does correct i18n lookup for nested has_many models when child_index contains non-word characters' do
+    @user.tags = [Tag.new(1, 'Empresa')]
+
+    store_translations(:en, simple_form: { labels: {
+      user: { name: 'Usuario' },
+      tags: { name: 'Nome da empresa' }
+    } }) do
+      with_concat_form_for @user do |f|
+        concat f.input :name
+        concat(f.simple_fields_for(:tags, child_index: "#index") do |tags_form|
+          concat(tags_form.input :name)
+        end)
+      end
+
+      assert_select 'label[for=user_name]', /Usuario/
+      assert_select 'label', text: /Nome da empresa/
+    end
+  end
+
   test 'label has css class from type' do
     with_label_for @user, :name, :string
     assert_select 'label.string'


### PR DESCRIPTION
Closes #1795

## Problem

`lookup_model_names` uses the regex `/(?!\d)\w+/` to scan `object_name` into segments, then attempts to remove `child_index` from the result via `names.delete(child_index)`.

When `child_index` contains non-word characters (e.g. `"#index"`), the regex never captures it as a single segment, so `delete` silently does nothing. This leaves stale segments in the lookup names, breaking I18n resolution for hints, labels, and other translated components in nested forms.

## Solution

Remove `child_index` (with its surrounding brackets) from the `object_name` string **before** the regex scan, rather than trying to delete it from the results afterward. This handles any `child_index` value regardless of the characters it contains.

## Verification

- Added a test for `child_index: "#index"` (non-word character case)
- Full test suite passes (807 runs, 0 failures)