### PR TITLE
Clarify that browser_validations default differs between gem and generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1173,6 +1173,11 @@ the browser validation:
 SimpleForm.browser_validations = false # default is true
 ```
 
+Note: while `true` is the default when SimpleForm is loaded, running `rails generate simple_form:install`
+creates an initializer that explicitly sets this to `false`, as it is the recommended setting due to
+inconsistent native validation behavior across browsers. If you want the default `true` behavior, remove
+or comment out this line in `config/initializers/simple_form.rb`.
+
 This option adds a new `novalidate` property to the form, instructing it to skip all HTML 5
 validation. The inputs will still be generated with the required and other attributes, that might
 help you to use some generic javascript validation.


### PR DESCRIPTION
## What

The README states `SimpleForm.browser_validations` defaults to `true`,
but the install generator explicitly sets it to `false` in the
generated initializer.

## Why

This is intentional behaviour, documented in an inline comment in the
generator template, due to inconsistent native HTML5 validation
across browsers. However this distinction was not mentioned anywhere
in the README, leading users to reasonably expect `true` after
running `rails generate simple_form:install`, when in fact they get
`false`.

## Changes

Adds a short note in the README clarifying the difference between
the gem-level default and what the generator sets, and how to
restore the gem-level default if desired.

Fixes #1746